### PR TITLE
start implementing REPL test command

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -61,4 +61,19 @@ function up(env::EnvCache, pkgs::Vector{PackageSpec};
     Pkg3.Operations.up(env, pkgs)
 end
 
+test(;kwargs...)                           = test(PackageSpec[], kwargs...)
+test(pkg::String; kwargs...)               = test([pkg]; kwargs...)
+test(pkgs::Vector{String}; kwargs...)      = test([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
+test(pkgs::Vector{PackageSpec}; kwargs...) = test(EnvCache(), pkgs; kwargs...)
+
+function test(env::EnvCache, pkgs::Vector{PackageSpec}; coverage=false, preview=env.preview[])
+    env.preview[] = preview
+    preview && previewmode_info()
+    project_resolve!(env, pkgs)
+    manifest_resolve!(env, pkgs)
+    ensure_resolved(env, pkgs)
+    Pkg3.Operations.test(env, pkgs; coverage=coverage)
 end
+
+end # module
+

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -33,6 +33,9 @@ include("Operations.jl")
 include("REPLMode.jl")
 include("API.jl")
 
+import .API: add, rm, up, test
+const update = up
+
 @enum LoadErrorChoice LOAD_ERROR_QUERY LOAD_ERROR_INSTALL LOAD_ERROR_ERROR
 
 Base.@kwdef mutable struct GlobalSettings
@@ -56,7 +59,7 @@ if VERSION < v"0.7.0-DEV.2303"
     Base.find_in_path(name::String, wd::Void)   = _find_package(name)
     Base.find_in_path(name::String, wd::String) = _find_package(name)
 else
-    Base.find_package(name::String) = _find_package(name, )
+    Base.find_package(name::String) = _find_package(name)
 end
 
 function _find_package(name::String)
@@ -67,7 +70,6 @@ function _find_package(name::String)
     else
         name = string(base, ".jl")
     end
-
     info = Pkg3.Operations.package_env_info(base, verb = "use")
     info == nothing && @goto find_global
     haskey(info, "uuid") || @goto find_global


### PR DESCRIPTION
Put most of the scaffolding in place for doing `pkg> test Pakcage`.

What is left (to match Pkg2) is to do resolution and support test only dependencies.