### PR TITLE
add preview mode

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -4,11 +4,15 @@ import Pkg3
 using Pkg3.Types
 using Base.Random.UUID
 
-add(pkg::String)               = add([pkg])
-add(pkgs::Vector{String})      = add([PackageSpec(pkg) for pkg in pkgs])
-add(pkgs::Vector{PackageSpec}) = add(EnvCache(), pkgs)
+previewmode_info() = info("In preview mode")
 
-function add(env::EnvCache, pkgs::Vector{PackageSpec})
+add(pkg::String; kwargs...)               = add([pkg]; kwargs...)
+add(pkgs::Vector{String}; kwargs...)      = add([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
+add(pkgs::Vector{PackageSpec}; kwargs...) = add(EnvCache(), pkgs; kwargs...)
+
+function add(env::EnvCache, pkgs::Vector{PackageSpec}; preview::Bool=env.preview[])
+    env.preview[] = preview
+    preview && previewmode_info()
     project_resolve!(env, pkgs)
     registry_resolve!(env, pkgs)
     ensure_resolved(env, pkgs, true)
@@ -16,11 +20,13 @@ function add(env::EnvCache, pkgs::Vector{PackageSpec})
 end
 
 
-rm(pkg::String)               = rm([pkg])
-rm(pkgs::Vector{String})      = rm([PackageSpec(pkg) for pkg in pkgs])
-rm(pkgs::Vector{PackageSpec}) = rm(EnvCache(), pkgs)
+rm(pkg::String; kwargs...)               = rm([pkg]; kwargs...)
+rm(pkgs::Vector{String}; kwargs...)      = rm([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
+rm(pkgs::Vector{PackageSpec}; kwargs...) = rm(EnvCache(), pkgs; kwargs...)
 
-function rm(env::EnvCache, pkgs::Vector{PackageSpec})
+function rm(env::EnvCache, pkgs::Vector{PackageSpec}; preview::Bool=env.preview[])
+    env.preview[] = preview
+    preview && previewmode_info()
     project_resolve!(env, pkgs)
     manifest_resolve!(env, pkgs)
     Pkg3.Operations.rm(env, pkgs)
@@ -33,7 +39,9 @@ up(pkgs::Vector{String}; kwargs...)      = up([PackageSpec(pkg) for pkg in pkgs]
 up(pkgs::Vector{PackageSpec}; kwargs...) = up(EnvCache(), pkgs; kwargs...)
 
 function up(env::EnvCache, pkgs::Vector{PackageSpec};
-            level::UpgradeLevel=UpgradeLevel(:major), mode::Symbol=:project)
+            level::UpgradeLevel=UpgradeLevel(:major), mode::Symbol=:project, preview::Bool=env.preview[])
+    env.preview[] = preview
+    preview && previewmode_info()
     if isempty(pkgs)
         if mode == :project
             for (name::String, uuid::UUID) in env.project["deps"]

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -244,6 +244,7 @@ function install(
     version_path = find_installed(uuid, hash)
     ispath(version_path) && return version_path, false
     http_download_successful = false
+    env.preview[] && return version_path, true
     if !USE_LIBGIT2_FOR_ALL_DOWNLOADS && version != nothing
         for url in urls
             archive_url = get_archive_url_for_version(url, version)
@@ -429,6 +430,7 @@ end
 
 function build_versions(env::EnvCache, uuids::Vector{UUID})
     # collect builds for UUIDs with `deps/build.jl` files
+    env.preview[] && (info("Skipping building in preview mode"); return)
     builds = Tuple{UUID,String,SHA1,String}[]
     for uuid in uuids
         info = manifest_info(env, uuid)
@@ -473,6 +475,7 @@ function build_versions(env::EnvCache, uuids::Vector{UUID})
             warn("Error building `$name`; see log file for further info")
         end
     end
+    return
 end
 
 function rm(env::EnvCache, pkgs::Vector{PackageSpec})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,9 +15,13 @@ function temp_pkg_dir(fn::Function)
 end
 
 temp_pkg_dir() do
+    Pkg3.API.add("Example"; preview = true)
+    @test_warn "not in project" Pkg3.API.rm("Example")
     Pkg3.API.add("Example")
     @eval import Example
     Pkg3.API.up()
+    Pkg3.API.rm("Example"; preview = true)
+    # TODO: Check Example is still considered install
     Pkg3.API.rm("Example")
 
     nonexisting_pkg = randstring(14)


### PR DESCRIPTION
As a response to #34, this shows a possible implementation.

Any command can be called as `preview cmd` and the effects of the command will go through but with (hopefully) no side effects. This removes downloading, building, and writing to any Project or Manifest files.

Example:

![image](https://user-images.githubusercontent.com/1282691/32980254-4730e52a-cc63-11e7-9ade-7fd3963f7298.png)


