### PR TITLE
add cmdline binary

### DIFF
--- a/bin/juliapkg
+++ b/bin/juliapkg
@@ -1,0 +1,7 @@
+#!/usr/bin/env julia
+
+import Pkg3
+
+@eval Base have_color = true
+Pkg3.REPLMode.do_cmd(join(ARGS, " "))
+


### PR DESCRIPTION
This allows one to execute Pkg3 commands without explicitly starting Julia with `juliapkg ...`. Perhaps this could be added in the bin directory of julia.

The startup time is still horrible but that is probably related to #28

![image](https://user-images.githubusercontent.com/1282691/33188895-1d224050-d09e-11e7-8bdb-0b0d2f0c8cae.png)
