### PR TITLE
remove sha field from Available

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -116,7 +116,7 @@ load_package_data(f::Base.Callable, path::String, version::VersionNumber) =
     get(load_package_data(f, path, [version]), version, nothing)
 
 function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
-    deps = Dict{UUID,Dict{VersionNumber,Tuple{SHA1,Dict{UUID,VersionSpec}}}}()
+    deps = Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}}()
     uuids = [pkg.uuid for pkg in pkgs]
     seen = UUID[]
     while true
@@ -135,7 +135,7 @@ function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
                     r = get_or_make(Dict{String,VersionSpec}, compatibility, v)
                     q = Dict(u => get_or_make(VersionSpec, r, p) for (p, u) in d)
                     # VERSION in get_or_make(VersionSpec, r, "julia") || continue
-                    deps[uuid][v] = (h, q)
+                    deps[uuid][v] = q
                     for (p, u) in d
                         u in uuids || push!(uuids, u)
                     end

--- a/src/Pkg2/types.jl
+++ b/src/Pkg2/types.jl
@@ -142,17 +142,14 @@ satisfies(pkg::AbstractString, ver::VersionNumber, reqs::Requires) =
     !haskey(reqs, pkg) || in(ver, reqs[pkg])
 
 struct Available
-    sha1::String
     requires::Requires
 end
 
-==(a::Available, b::Available) = a.sha1 == b.sha1 && a.requires == b.requires
-hash(a::Available, h::UInt) = hash((a.sha1, a.requires), h + (0xbc8ae0de9d11d972 % UInt))
-copy(a::Available) = Available(a.sha1, copy(a.requires))
+==(a::Available, b::Available) = a.requires == b.requires
+hash(a::Available, h::UInt) = hash(a.requires, h + (0xbc8ae0de9d11d972 % UInt))
+copy(a::Available) = Available(copy(a.requires))
 
-show(io::IO, a::Available) = isempty(a.requires) ?
-    print(io, "Available(", repr(a.sha1), ")") :
-    print(io, "Available(", repr(a.sha1), ",", a.requires, ")")
+show(io::IO, a::Available) = print(io, "Available(", a.requires, ")")
 
 struct Fixed
     version::VersionNumber

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -138,7 +138,7 @@ Base.convert(::Type{VersionSet}, r::VersionRange{m,2}) where {m} =
 Base.convert(::Type{VersionSet}, r::VersionRange{m,3}) where {m} =
     VersionSet(VersionNumber(r.lower.t...), VersionNumber(r.upper[1], r.upper[2], r.upper[3]+1))
 Base.convert(::Type{VersionSet}, s::VersionSpec) = mapreduce(VersionSet, ∪, s.ranges)
-Base.convert(::Type{Available}, t::Tuple{SHA1,Dict{UUID,VersionSpec}}) = Available(t...)
+Base.convert(::Type{Available}, t::Dict{UUID,VersionSpec}) = Available(t)
 
 ## command errors (no stacktrace) ##
 


### PR DESCRIPTION
This doesn't seem to have any purpose in the way Pkg3 structure things (SHA is readily available from the Manifest as opposed to the REQUIRE file in Pkg2).

Does this makes sense to you @StefanKarpinski.