### PR TITLE
WIP force explicit init using `init` for local env

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,0 @@
-authors = "Stefan Karpinski <stefan@karpinski.org>"
-desc = "The next-generation Julia package manager."
-keywords = ["package", "management"]
-license = "MIT"
-name = "Pkg3"
-repo = "https://github.com/StefanKarpinski/Pkg3.jl.git"
-
-[deps]
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/src/API.jl
+++ b/src/API.jl
@@ -224,5 +224,9 @@ function gc(env::EnvCache=EnvCache(); period = Week(6), preview=env.preview[])
     info("Deleted $(length(paths_to_delete)) package installations", byte_save_str)
 end
 
+function init(path = pwd())
+    Pkg3.Operations.init(path)
+end
+
 end # module
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -400,7 +400,8 @@ function apply_versions(env::EnvCache, pkgs::Vector{PackageSpec})::Vector{UUID}
     end
 
     textwidth = VERSION < v"0.7.0-DEV.1930" ? Base.strwidth : Base.textwidth
-    max_name = maximum(textwidth(names[pkg.uuid]) for pkg in pkgs)
+    widths = [textwidth(names[pkg.uuid]) for pkg in pkgs]
+    max_name = length(widths) == 0 ? 0 : maximum(widths)
 
     for _ in 1:length(pkgs)
         r = take!(results)
@@ -676,12 +677,10 @@ function init(path::String)
         err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
     end
     path = gitpath == nothing ? path : dirname(dirname(gitpath))
-    try mkpath(path) end
-    for f in ("Project.toml", "Manifest.toml")
-        isfile(joinpath(path, f)) && cmderror("Project already initialized at $path")
-    end
+    mkpath(path)
+    isfile(joinpath(path, "Project.toml")) && cmderror("Environment already initialized at $path")
     touch(joinpath(path, "Project.toml"))
-    info("Initialized project in $path by creating the file Project.toml")
+    info("Initialized environment in $path by creating the file Project.toml")
 end
 
 end # module

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -41,7 +41,7 @@ include("Operations.jl")
 include("REPLMode.jl")
 include("API.jl")
 
-import .API: add, rm, up, test, gc
+import .API: add, rm, up, test, gc, init
 const update = up
 
 @enum LoadErrorChoice LOAD_ERROR_QUERY LOAD_ERROR_INSTALL LOAD_ERROR_ERROR

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -57,10 +57,9 @@ temp_pkg_dir() do project_path
         LibGit2.init(tmp)
         mkdir(joinpath(tmp, "subfolder"))
         cd(joinpath(tmp, "subfolder")) do
+            # Haven't initialized here so using the default env
+            @test isinstalled(TEST_PKG)
             withenv("JULIA_ENV" => nothing) do
-                # Haven't initialized here so using the default env
-                @test isinstalled(TEST_PKG)
-                # Initializing, createa a new env
                 Pkg3.init()
                 @test !isinstalled(TEST_PKG)
                 @test isfile(joinpath(tmp, "Project.toml"))

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -17,26 +17,27 @@ function temp_pkg_dir(fn::Function)
     end
 end
 
+isinstalled(pkg) = Pkg3._find_package(pkg) != nothing
+
 # Tests for Example.jl fail on master,
 # so let's use another small package
 # in the meantime
 const TEST_PKG = "Crayons"
 
 temp_pkg_dir() do project_path
+    Pkg3.init(project_path)
     Pkg3.add(TEST_PKG; preview = true)
     @test_warn "not in project" Pkg3.API.rm("Example")
     Pkg3.add(TEST_PKG)
     @eval import $(Symbol(TEST_PKG))
     Pkg3.up()
     Pkg3.rm(TEST_PKG; preview = true)
-
+    @test isinstalled(TEST_PKG)
     # TODO: Check coverage kwargs
     # TODO: Check that preview = true doesn't actually execute the test
     # by creating a package with a test file that fails.
     Pkg3.test(TEST_PKG)
     Pkg3.test(TEST_PKG; preview = true)
-
-    Pkg3.rm(TEST_PKG)
 
     try
         Pkg3.add([PackageSpec(TEST_PKG, VersionSpec(v"55"))])
@@ -51,6 +52,25 @@ temp_pkg_dir() do project_path
     @test_throws CommandError Pkg3.add(nonexisting_pkg)
     @test_throws CommandError Pkg3.up(nonexisting_pkg)
     @test_warn "not in project" Pkg3.rm(nonexisting_pkg)
+
+    mktempdir() do tmp
+        LibGit2.init(tmp)
+        mkdir(joinpath(tmp, "subfolder"))
+        cd(joinpath(tmp, "subfolder")) do
+            withenv("JULIA_ENV" => nothing) do
+                # Haven't initialized here so using the default env
+                @test isinstalled(TEST_PKG)
+                # Initializing, createa a new env
+                Pkg3.init()
+                @test !isinstalled(TEST_PKG)
+                @test isfile(joinpath(tmp, "Project.toml"))
+            end
+        end
+    end
+
+    Pkg3.rm(TEST_PKG)
+    @test !isinstalled(TEST_PKG)
+
 end
 
 end # module


### PR DESCRIPTION
On its way to solve #40. The idea is to never automatically create a local env, instead you can run `init` which will create that env in the current folder or the base of a git folder.

WIP because it needs tests and more cleanup. cc @fredrikekre 