### PR TITLE
implement cloning (and the inverse, freeing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,5 @@ before_script:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Pkg3"); Pkg.test("Pkg3"; coverage=true)'
-
-after_success:
-  - julia -e 'cd(Pkg.dir("Pkg3")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia --check-bounds=yes -e 'include("src/Pkg3.jl"); Pkg3.clone(pwd()); Pkg3.test("Pkg3"; coverage=true)'
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.6
 SHA
-# Pkg.clone("https://github.com/StefanKarpinski/TOML.jl.git")

--- a/ext/BinaryProvider/src/BinaryProvider.jl
+++ b/ext/BinaryProvider/src/BinaryProvider.jl
@@ -1,19 +1,19 @@
 module BinaryProvider
 
-import Pkg3: iswindows, isapple, islinux
+import ..Pkg3: iswindows, isapple, islinux
 
 # Include our subprocess running funtionality
-include("OutputCollector.jl")
+#include("OutputCollector.jl")
 # External utilities such as downloading/decompressing tarballs
 include("PlatformEngines.jl")
 # Platform naming
-include("PlatformNames.jl")
+#include("PlatformNames.jl")
 # Everything related to file/path management
-include("Prefix.jl")
+#include("Prefix.jl")
 # Abstraction of "needing" a file, that would trigger an install
-include("Products.jl")
+#include("Products.jl")
 # Abstraction of bundled binary package
-include("BinaryPackage.jl")
+#include("BinaryPackage.jl")
 
 # BinDeps support, disabled for now because I don't particularly want to force
 # users to install BinDeps to install this package.  That seems counter-productive

--- a/ext/TerminalMenus/src/TerminalMenus.jl
+++ b/ext/TerminalMenus/src/TerminalMenus.jl
@@ -1,6 +1,6 @@
 module TerminalMenus
 
-import Pkg3.iswindows
+import ..Pkg3.iswindows
 
 terminal = nothing  # The user terminal
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -116,7 +116,7 @@ load_package_data(f::Base.Callable, path::String, version::VersionNumber) =
     get(load_package_data(f, path, [version]), version, nothing)
 
 function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
-    deps = Dict{UUID,Dict{VersionNumber,Tuple{SHA1,Dict{UUID,VersionSpec}}}}()
+    deps = Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}}()
     uuids = [pkg.uuid for pkg in pkgs]
     seen = UUID[]
     while true
@@ -135,7 +135,7 @@ function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
                     r = get_or_make(Dict{String,VersionSpec}, compatibility, v)
                     q = Dict(u => get_or_make(VersionSpec, r, p) for (p, u) in d)
                     # VERSION in get_or_make(VersionSpec, r, "julia") || continue
-                    deps[uuid][v] = (h, q)
+                    deps[uuid][v] = q
                     for (p, u) in d
                         u in uuids || push!(uuids, u)
                     end

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -153,38 +153,26 @@ function collect_fixed!(env, pkgs, uuids)
     fix_deps_map = Dict{UUID, Vector{PackageSpec}}()
     uuid_to_pkg = Dict{UUID, PackageSpec}()
     for pkg in pkgs
-        path    = nothing
-        version = nothing
-        has_path(pkg) && (path = pkg.path)
-        has_version(pkg) && (version = pkg.version)
-        info = manifest_info(env, pkg.uuid)
-        version == nothing && info != nothing && haskey(info, "version") && (version = VersionNumber(info["version"]))
-        path == nothing && info != nothing && haskey(info, "path") && (path = info["path"])
-        if path != nothing # This is a fixed package
-            # Package is actually being freed, so it is not fixed
-            pkg.beingfreed && continue
-            # A package with a path should have a version
-            @assert version != nothing
-            pkg.path = path
-            pkg.version = version
+        !has_path(pkg) && continue
+        # A package with a path should have a version
+        @assert pkg.version != nothing
 
-            uuid_to_pkg[pkg.uuid] = pkg
-            # Load the dependencies if this package has a REQUIRE
-            reqfile = joinpath(path, "REQUIRE")
-            fix_deps_map[pkg.uuid] = valtype(fix_deps_map)()
-            !isfile(reqfile) && continue
-            for r in filter!(r->r isa Pkg2.Reqs.Requirement, Pkg2.Reqs.read(reqfile))
-                # @assert length(r.versions.intervals) == 1
-                pkg_name, version = r.package, r.versions.intervals[1]
-                # TODO: Check VERSION
-                pkg_name == "julia" && continue
-                # Convert to Pkg3 data types
-                vspec = VersionSpec([VersionRange(VersionBound(version.lower),
-                                                  VersionBound(version.upper))])
-                deppkg = PackageSpec(pkg_name, vspec)
-                push!(fix_deps_map[pkg.uuid], deppkg)
-                push!(fix_deps, deppkg)
-            end
+        uuid_to_pkg[pkg.uuid] = pkg
+        # Load the dependencies if this package has a REQUIRE
+        reqfile = joinpath(pkg.path, "REQUIRE")
+        fix_deps_map[pkg.uuid] = valtype(fix_deps_map)()
+        !isfile(reqfile) && continue
+        for r in filter!(r->r isa Pkg2.Reqs.Requirement, Pkg2.Reqs.read(reqfile))
+            # @assert length(r.versions.intervals) == 1
+            pkg_name, version = r.package, r.versions.intervals[1]
+            # TODO: Check VERSION
+            pkg_name == "julia" && continue
+            # Convert to Pkg3 data types
+            vspec = VersionSpec([VersionRange(VersionBound(version.lower),
+                                              VersionBound(version.upper))])
+            deppkg = PackageSpec(pkg_name, vspec)
+            push!(fix_deps_map[pkg.uuid], deppkg)
+            push!(fix_deps, deppkg)
         end
     end
 
@@ -221,6 +209,7 @@ function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec})::Dict{UUID,
         ver = VersionNumber(info["version"])
         push!(pkgs, PackageSpec(name, uuid, ver))
     end
+    path_resolve!(env, pkgs)
 
     # Collect all fixed packages (have a path) and their dependencies
     fixed = collect_fixed!(env, pkgs, uuids)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -2,9 +2,8 @@ module Operations
 
 using Base.Random: UUID
 using Base: LibGit2
-using Pkg3.TerminalMenus
-using Pkg3.Types
-import Pkg3: Pkg2, depots, BinaryProvider, USE_LIBGIT2_FOR_ALL_DOWNLOADS, NUM_CONCURRENT_DOWNLOADS
+using ..Pkg3: TerminalMenus, Types
+import ..Pkg3: Pkg2, depots, equalto, BinaryProvider, USE_LIBGIT2_FOR_ALL_DOWNLOADS, NUM_CONCURRENT_DOWNLOADS
 
 const SlugInt = UInt32 # max p = 4
 const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
@@ -115,7 +114,7 @@ end
 load_package_data(f::Base.Callable, path::String, version::VersionNumber) =
     get(load_package_data(f, path, [version]), version, nothing)
 
-function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
+function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec}, reqs)
     deps = Dict{UUID,Dict{VersionNumber,Dict{UUID,VersionSpec}}}()
     uuids = [pkg.uuid for pkg in pkgs]
     seen = UUID[]
@@ -147,6 +146,67 @@ function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
     return deps
 end
 
+# This also sets the .path field for fixed packages in `pkgs`
+function collect_fixed!(env, pkgs, uuids)
+    fix_deps = PackageSpec[]
+    fixed_pkgs = PackageSpec[]
+    fix_deps_map = Dict{UUID, Vector{PackageSpec}}()
+    uuid_to_pkg = Dict{UUID, PackageSpec}()
+    for pkg in pkgs
+        path    = nothing
+        version = nothing
+        has_path(pkg) && (path = pkg.path)
+        has_version(pkg) && (version = pkg.version)
+        info = manifest_info(env, pkg.uuid)
+        version == nothing && info != nothing && haskey(info, "version") && (version = VersionNumber(info["version"]))
+        path == nothing && info != nothing && haskey(info, "path") && (path = info["path"])
+        if path != nothing # This is a fixed package
+            # Package is actually being freed, so it is not fixed
+            pkg.beingfreed && continue
+            # A package with a path should have a version
+            @assert version != nothing
+            pkg.path = path
+            pkg.version = version
+
+            uuid_to_pkg[pkg.uuid] = pkg
+            # Load the dependencies if this package has a REQUIRE
+            reqfile = joinpath(path, "REQUIRE")
+            fix_deps_map[pkg.uuid] = valtype(fix_deps_map)()
+            !isfile(reqfile) && continue
+            for r in filter!(r->r isa Pkg2.Reqs.Requirement, Pkg2.Reqs.read(reqfile))
+                # @assert length(r.versions.intervals) == 1
+                pkg_name, version = r.package, r.versions.intervals[1]
+                # TODO: Check VERSION
+                pkg_name == "julia" && continue
+                # Convert to Pkg3 data types
+                vspec = VersionSpec([VersionRange(VersionBound(version.lower),
+                                                  VersionBound(version.upper))])
+                deppkg = PackageSpec(pkg_name, vspec)
+                push!(fix_deps_map[pkg.uuid], deppkg)
+                push!(fix_deps, deppkg)
+            end
+        end
+    end
+
+    # Look up the UUIDS for all the fixed dependencies in the registry in one shot
+    registry_resolve!(env, fix_deps)
+    fixed = Dict{String, Pkg2.Types.Fixed}()
+    # Collect the dependencies for the fixed packages
+    for (uuid, fixed_pkgs) in fix_deps_map
+        fix_pkg = uuid_to_pkg[uuid]
+        v = Dict{VersionNumber,Dict{UUID,VersionSpec}}()
+        q = Dict{UUID, VersionSpec}()
+        for deppkg in fixed_pkgs
+            if !has_uuid(deppkg)
+                cmderror("Could not find a UUID for package $(pkg.name) in the registry")
+            end
+            q[deppkg.uuid] = deppkg.version
+        end
+        fixed[string(uuid)] = Pkg2.Types.Fixed(fix_pkg.version, q)
+    end
+    return fixed
+end
+
 "Resolve a set of versions given package version specs"
 function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec})::Dict{UUID,VersionNumber}
     info("Resolving package versions")
@@ -161,21 +221,34 @@ function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec})::Dict{UUID,
         ver = VersionNumber(info["version"])
         push!(pkgs, PackageSpec(name, uuid, ver))
     end
-    # construct data structures for resolver and call it
+
+    # Collect all fixed packages (have a path) and their dependencies
+    fixed = collect_fixed!(env, pkgs, uuids)
     reqs = Dict{String,Pkg2.Types.VersionSet}(string(pkg.uuid) => pkg.version for pkg in pkgs)
-    deps = convert(Dict{String,Dict{VersionNumber,Pkg2.Types.Available}}, deps_graph(env, pkgs))
+    bktrc = Pkg2.Query.init_resolve_backtrace(reqs, fixed)
+    Pkg2.Query.check_fixed(reqs, fixed, uuid_to_name)
+    Pkg2.Query.propagate_fixed!(reqs, bktrc, fixed)
+    # New requirements from the propagation should be added to the list of pacakges
+    for uuid in keys(reqs)
+        if !(uuid in uuids)
+            push!(pkgs, PackageSpec(UUID(uuid)))
+        end
+    end
+    deps = convert(Dict{String,Dict{VersionNumber,Pkg2.Types.Available}}, deps_graph(env, pkgs, reqs))
     for dep_uuid in keys(deps)
         info = manifest_info(env, UUID(dep_uuid))
         if info != nothing
             uuid_to_name[info["uuid"]] = info["name"]
         end
     end
-    deps = Pkg2.Query.prune_dependencies(reqs, deps, uuid_to_name)
+    deps = Pkg2.Query.prune_dependencies(reqs, deps, uuid_to_name, bktrc)
     vers = convert(Dict{UUID,VersionNumber}, Pkg2.Resolve.resolve(reqs, deps, uuid_to_name))
     find_registered!(env, collect(keys(vers)))
     # update vector of package versions
     for pkg in pkgs
-        pkg.version = vers[pkg.uuid]
+        if !has_path(pkg) # Fixed packages already have their version set
+            pkg.version = vers[pkg.uuid]
+        end
     end
     uuids = UUID[pkg.uuid for pkg in pkgs]
     for (uuid, ver) in vers
@@ -217,7 +290,7 @@ function version_data(env::EnvCache, pkgs::Vector{PackageSpec})
                 end
             end
         end
-        @assert haskey(hashes, uuid)
+        # @assert haskey(hashes, uuid)
     end
     foreach(sort!, values(upstreams))
     return names, hashes, upstreams
@@ -312,7 +385,7 @@ function install(
     return version_path, true
 end
 
-function update_manifest(env::EnvCache, uuid::UUID, name::String, hash::SHA1, version::VersionNumber)
+function update_manifest(env::EnvCache, uuid::UUID, name::String, hash::Union{Void, SHA1}, version::VersionNumber, path::AbstractString)
     infos = get!(env.manifest, name, Dict{String,Any}[])
     info = nothing
     for i in infos
@@ -325,13 +398,41 @@ function update_manifest(env::EnvCache, uuid::UUID, name::String, hash::SHA1, ve
         push!(infos, info)
     end
     info["version"] = string(version)
-    info["hash-sha1"] = string(hash)
+    if isempty(path)
+        @assert hash != nothing
+        haskey(info, "path") && delete!(info, "path")
+        info["hash-sha1"] = string(hash)
+    else
+        haskey(info, "hash-sha1") && delete!(info, "hash-sha1")
+        info["path"] = path
+    end
     delete!(info, "deps")
-    for path in registered_paths(env, uuid)
-        data = load_package_data(UUID, joinpath(path, "dependencies.toml"), version)
-        data == nothing && continue
-        info["deps"] = convert(Dict{String,String}, data)
-        break
+    if !isempty(path)
+        reqfile = joinpath(path, "REQUIRE")
+
+        !isfile(reqfile) && return
+        deps = Dict{String, String}()
+        pkgs = PackageSpec[]
+        for r in filter!(r->r isa Pkg2.Reqs.Requirement, Pkg2.Reqs.read(reqfile))
+            push!(pkgs, PackageSpec(r.package))
+        end
+        # TODO: Get rid of this one?
+        registry_resolve!(env, pkgs)
+        for pkg in pkgs
+            pkg.name == "julia" && continue
+            @assert pkg.uuid != UUID(zero(UInt128))
+            deps[pkg.name] = pkg.uuid
+        end
+        if !isempty(deps)
+            info["deps"] = deps
+        end
+    else
+        for path in registered_paths(env, uuid)
+            data = load_package_data(UUID, joinpath(path, "dependencies.toml"), version)
+            data == nothing && continue
+            info["deps"] = convert(Dict{String,String}, data)
+            break
+        end
     end
     return info
 end
@@ -385,11 +486,16 @@ function apply_versions(env::EnvCache, pkgs::Vector{PackageSpec})::Vector{UUID}
     for i in 1:NUM_CONCURRENT_DOWNLOADS
         @schedule begin
             for pkg in jobs
+                # Check if this is a local package
+                if has_path(pkg)
+                    put!(results, (pkg, pkg.path, pkg.version, nothing, false))
+                    continue
+                end
                 uuid = pkg.uuid
                 version = pkg.version::VersionNumber
-                name, hash = names[uuid], hashes[uuid]
+                name, hash, url = names[uuid], hashes[uuid], urls[uuid]
                 try
-                    version_path, new = install(env, uuid, name, hash, urls[uuid], version)
+                    version_path, new = install(env, uuid, name, hash, url, version)
                     put!(results, (pkg, version_path, version, hash, new))
                 catch e
                     put!(results, e)
@@ -399,7 +505,8 @@ function apply_versions(env::EnvCache, pkgs::Vector{PackageSpec})::Vector{UUID}
     end
 
     textwidth = VERSION < v"0.7.0-DEV.1930" ? Base.strwidth : Base.textwidth
-    max_name = maximum(textwidth(names[pkg.uuid]) for pkg in pkgs)
+    widths = [textwidth(names[pkg.uuid]) for pkg in pkgs if haskey(names, pkg.uuid)]
+    max_name = (length(widths) == 0) ? 0 : maximum(widths)
 
     for _ in 1:length(pkgs)
         r = take!(results)
@@ -409,10 +516,14 @@ function apply_versions(env::EnvCache, pkgs::Vector{PackageSpec})::Vector{UUID}
             vstr = version != nothing ? "v$version" : "[$h]"
             new && info("Installed $(rpad(names[pkg.uuid] * " ", max_name + 2, "─")) $vstr")
         end
-        uuid = pkg.uuid
+        uuid, path = pkg.uuid, pkg.path
         version = pkg.version::VersionNumber
-        name, hash = names[uuid], hashes[uuid]
-        update_manifest(env, uuid, name, hash, version)
+        if haskey(names, uuid)
+            name, hash = names[uuid], hashes[uuid]
+        else
+            name, hash = pkg.name, nothing
+        end
+        update_manifest(env, uuid, name, hash, version, path)
         new && push!(new_versions, uuid)
     end
     prune_manifest(env)
@@ -446,10 +557,12 @@ function build_versions(env::EnvCache, uuids::Vector{UUID})
     for uuid in uuids
         info = manifest_info(env, uuid)
         name = info["name"]
-        # TODO: handle development packages?
-        haskey(info, "hash-sha1") || continue
-        hash = SHA1(info["hash-sha1"])
-        path = find_installed(uuid, hash)
+        path = if haskey(info, "path")
+            info["path"]
+        else
+            hash = SHA1(info["hash-sha1"])
+            find_installed(uuid, hash)
+        end
         ispath(path) || error("Build path for $name does not exist: $path")
         build_file = joinpath(path, "deps", "build.jl")
         ispath(build_file) && push!(builds, (uuid, name, hash, build_file))
@@ -613,8 +726,12 @@ function test(env::EnvCache, pkgs::Vector{PackageSpec}; coverage=false)
     version_paths    = String[]
     for pkg in pkgs
         info = manifest_info(env, pkg.uuid)
-        haskey(info, "hash-sha1") || cmderror("Could not find hash-sha for package $(pkg.name)")
-        version_path = find_installed(pkg.uuid, SHA1(info["hash-sha1"]))
+        version_path = if haskey(info, "path")
+            info["path"]
+        else
+            haskey(info, "hash-sha1") || cmderror("Could not find hash-sha for package $(pkg.name)")
+            find_installed(pkg.uuid, SHA1(info["hash-sha1"]))
+        end
         testfile = joinpath(version_path, "test", "runtests.jl")
         if !isfile(testfile)
             push!(missing_runtests, pkg.name)
@@ -666,5 +783,64 @@ function test(env::EnvCache, pkgs::Vector{PackageSpec}; coverage=false)
                  " errored during testing")
     end
 end
+
+function clone(env::EnvCache, pkgs::Vector{PackageSpec})
+    new_repos = Dict{UUID, String}()
+    for pkg in pkgs
+        if has_uuid(pkg)
+            # This is a registered package, set its version to the maximum version
+            # since we will clone master
+            uuid = pkg.uuid
+            max_version = typemin(VersionNumber)
+            for path in registered_paths(env, uuid)
+                version_info = load_versions(path)
+                max_version = max(max_version, maximum(keys(version_info)))
+            end
+            pkg.version = max_version
+        else
+            # We are cloning a packages that doesn't exist in the registry.
+            # Give it a new UUID and some version
+            pkg.version = v"0.0"
+            pkg.uuid = uuid5(uuid_package, pkg.name)
+        end
+        if isdir(joinpath(pkg.path))
+            if !isfile(joinpath(pkg.path, "src", pkg.name * ".jl"))
+                cmderror("Path $(pkg.path) exists but it does not contain `src/$(pkg).jl.")
+            end
+            info("Path $(pkg.path) exists and looks like a package, using that.")
+        else
+            info("Cloning $(pkg.name) from $(pkg.url) to $(pkg.path)")
+            mkpath(pkg.path)
+            new_repos[pkg.uuid] = pkg.path
+            LibGit2.clone(pkg.url, pkg.path)
+        end
+        env.project["deps"][pkg.name] = string(pkg.uuid)
+    end
+    try
+        resolve_versions!(env, pkgs)
+        new = apply_versions(env, pkgs)
+        write_env(env)
+        build_versions(env, new)
+    catch e
+        for pkg in pkgs
+            haskey(new_repos, pkg.uuid) && Base.rm(new_repos[pkg.uuid]; recursive = true)
+        end
+        rethrow(e)
+    end
+end
+
+function free(env::EnvCache, pkgs::Vector{PackageSpec})
+    for pkg in pkgs
+        if isempty(registered_name(env, pkg.uuid))
+            cmderror("can only free registered packages")
+        end
+        pkg.beingfreed = true
+    end
+    resolve_versions!(env, pkgs)
+    new = apply_versions(env, pkgs)
+    write_env(env) # write env before building
+    build_versions(env, new)
+end
+
 end # module
 

--- a/src/Pkg2/query.jl
+++ b/src/Pkg2/query.jl
@@ -4,7 +4,7 @@ module Query
 
 import ..PkgError
 using ..Types
-import Pkg3.equalto
+import ...Pkg3.equalto
 
 function init_resolve_backtrace(reqs::Requires, fix::Dict{String,Fixed} = Dict{String,Fixed}())
     bktrc = ResolveBacktrace()
@@ -18,9 +18,10 @@ function init_resolve_backtrace(reqs::Requires, fix::Dict{String,Fixed} = Dict{S
     return bktrc
 end
 
-function check_fixed(reqs::Requires, fix::Dict{String,Fixed}, avail::Dict, uuid_to_name::Dict{String, String})
+function check_fixed(reqs::Requires, fix::Dict{String,Fixed}, uuid_to_name::Dict{String, String})
     for (p1,f1) in fix
         for p2 in keys(f1.requires)
+            #=
             if !(haskey(avail, p2) || haskey(fix, p2))
                 name1 = haskey(uuid_to_name, p1) ? uuid_to_name[p1] : "UNKNOWN"
                 uuid_short1 = p1[1:8]
@@ -28,6 +29,7 @@ function check_fixed(reqs::Requires, fix::Dict{String,Fixed}, avail::Dict, uuid_
                 uuid_short2 = p2[1:8]
                 throw(PkgError("unknown package $name2 [$uuid_short2] required by $name1 [$uuid_short1]"))
             end
+            =#
         end
         if !satisfies(p1, f1.version, reqs)
             name1 = haskey(uuid_to_name, p1) ? uuid_to_name[p1] : "UNKNOWN"

--- a/src/Pkg2/types.jl
+++ b/src/Pkg2/types.jl
@@ -6,7 +6,7 @@ export VersionInterval, VersionSet, Requires, Available, Fixed, merge_requires!,
        ResolveBacktraceItem, ResolveBacktrace
 import Base: show, isempty, in, intersect, union!, union, ==, hash, copy, deepcopy_internal, push!
 
-import Pkg3.equalto
+import ...Pkg3.equalto
 import ...iswindows
 
 struct VersionInterval

--- a/src/Pkg2/types.jl
+++ b/src/Pkg2/types.jl
@@ -142,17 +142,14 @@ satisfies(pkg::AbstractString, ver::VersionNumber, reqs::Requires) =
     !haskey(reqs, pkg) || in(ver, reqs[pkg])
 
 struct Available
-    sha1::String
     requires::Requires
 end
 
-==(a::Available, b::Available) = a.sha1 == b.sha1 && a.requires == b.requires
-hash(a::Available, h::UInt) = hash((a.sha1, a.requires), h + (0xbc8ae0de9d11d972 % UInt))
-copy(a::Available) = Available(a.sha1, copy(a.requires))
+==(a::Available, b::Available) = a.requires == b.requires
+hash(a::Available, h::UInt) = hash(a.requires, h + (0xbc8ae0de9d11d972 % UInt))
+copy(a::Available) = Available(copy(a.requires))
 
-show(io::IO, a::Available) = isempty(a.requires) ?
-    print(io, "Available(", repr(a.sha1), ")") :
-    print(io, "Available(", repr(a.sha1), ",", a.requires, ")")
+show(io::IO, a::Available) = print(io, "Available(", a.requires, ")")
 
 struct Fixed
     version::VersionNumber

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -1,9 +1,8 @@
 module REPLMode
 
-import Pkg3
-using Pkg3.Types
-using Pkg3.Display
-using Pkg3.Operations
+import ..Pkg3
+import Pkg3: DEFAULT_DEV_PATH
+using ..Pkg3: Types, Display, Operations
 
 import Base: LineEdit, REPL, REPLCompletions
 import Base.Random: UUID
@@ -32,6 +31,8 @@ const cmds = Dict(
     "gc"        => :gc,
     "fsck"      => :fsck,
     "preview"   => :preview,
+    "clone"     => :clone,
+    "free"      => :free,
 )
 
 const opts = Dict(
@@ -45,6 +46,8 @@ const opts = Dict(
     "patch"    => :patch,
     "fixed"    => :fixed,
     "coverage" => :coverage,
+    "path"     => :path,
+    "name"     => :name,
 )
 
 function parse_option(word::AbstractString)
@@ -155,6 +158,8 @@ function do_cmd!(env, tokens, repl)
     cmd == :status  ?  do_status!(env, tokens) :
     cmd == :test    ?    do_test!(env, tokens) :
     cmd == :gc      ?      do_gc!(env, tokens) :
+    cmd == :clone   ?   do_clone!(env, tokens) :
+    cmd == :free    ?    do_free!(env, tokens) :
         cmderror("`$cmd` command not yet implemented")
 end
 
@@ -200,6 +205,10 @@ const help = Base.Markdown.parse("""
     `test`: run tests for packages
 
     `gc`: garbage collect packages not used for a significant time
+
+    `clone`: clones a package from an url to a local directory
+
+    `free`: start using the registered version of a package instead of the cloned one
     """)
 
 const helps = Dict(
@@ -288,6 +297,24 @@ const helps = Dict(
     """, :gc => md"""
 
     Deletes packages that are not reached from any environment used within the last 6 weeks.
+    """, :clone => md"""
+
+        clone url [--path localpath]
+
+    Clones the package from the git repo at `url` to the path `localpath`, defaulting to `.julia/dev/`
+    in the home directory. A cloned package have its dependencies read from the packages local dependency file
+    instead of the registry. It is never be upgraded, removed, or changed in any way by
+    the package manager. If the package `localpath` exist, no cloning is done and the existing
+    package at that path is used. To `free` a package, i.e., go back to using the the versioned
+    package, use `free`.
+    """, :free => md"""
+
+        free pkg[=uuid]
+
+    Undo the clone command on `pkg`, i.e., instead of using the path where `pkg`
+    was cloned to when loading it, use the standard versioned path.
+    This allows the package to again be upgraded.
+    The directory where the package was originally cloned at is left untouched.
     """
 )
 
@@ -458,6 +485,50 @@ end
 function do_gc!(env::EnvCache, tokens::Vector{Tuple{Symbol,Vararg{Any}}})
     !isempty(tokens) && cmderror("`gc` does not take any arguments")
     Pkg3.API.gc(env)
+end
+
+function do_clone!(env::EnvCache, tokens::Vector{Tuple{Symbol,Vararg{Any}}})
+    isempty(tokens) && cmderror("`clone` take an url to a package to clone")
+    local url
+    basepath = get(ENV, "JULIA_DEV_PATH", DEFAULT_DEV_PATH)
+    token = shift!(tokens)
+    if token[1] != :string
+        cmderror("expected a url given as a string")
+    end
+    url = token[2]
+    if !isempty(tokens)
+        token = shift!(tokens)
+        if token[1] == :opt
+            if token[2] == :path
+                if isempty(tokens)
+                    cmderror("expected an argument to the `--path` option")
+                else
+                    token = shift!(tokens)
+                    if token[1] != :string
+                        cmderror("expecetd a string argument to the `--path` option")
+                    else
+                        basepath = token[2]
+                    end
+                end
+            else
+                cmderror("`clone` only support the `--path` option")
+            end
+        end
+    end
+    Pkg3.API.clone(env, url, basepath = basepath)
+end
+
+function do_free!(env::EnvCache, tokens::Vector{Tuple{Symbol,Vararg{Any}}})
+    pkgs = PackageSpec[]
+    while !isempty(tokens)
+        token = shift!(tokens)
+        if token[1] == :pkg
+            push!(pkgs, PackageSpec(token[2:end]...))
+        else
+            cmderror("free only takes a list of packages")
+        end
+    end
+    Pkg3.API.free(env, pkgs)
 end
 
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -137,7 +137,7 @@ Base.convert(::Type{VersionSet}, r::VersionRange{m,2}) where {m} =
 Base.convert(::Type{VersionSet}, r::VersionRange{m,3}) where {m} =
     VersionSet(VersionNumber(r.lower.t...), VersionNumber(r.upper[1], r.upper[2], r.upper[3]+1))
 Base.convert(::Type{VersionSet}, s::VersionSpec) = mapreduce(VersionSet, ∪, s.ranges)
-Base.convert(::Type{Available}, t::Tuple{SHA1,Dict{UUID,VersionSpec}}) = Available(t...)
+Base.convert(::Type{Available}, t::Dict{UUID,VersionSpec}) = Available(t)
 
 ## command errors (no stacktrace) ##
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -529,6 +529,17 @@ function registry_resolve!(env::EnvCache, pkgs::AbstractVector{PackageSpec})
     return pkgs
 end
 
+
+function path_resolve!(env::EnvCache, pkgs::AbstractVector{PackageSpec})
+    for pkg in pkgs
+        pkg.beingfreed && continue
+        info = manifest_info(env, pkg.uuid)
+        info == nothing && continue
+        haskey(info, "path") && (pkg.path = info["path"])
+        haskey(info, "version") && (pkg.version = VersionNumber(info["version"]))
+    end
+end
+
 "Ensure that all packages are fully resolved"
 function ensure_resolved(
     env::EnvCache,

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -50,6 +50,7 @@ temp_pkg_dir() do project_path
     # Clone an unregistered packge and check that it can be imported
     Pkg3.clone("https://github.com/fredrikekre/ImportMacros.jl")
     @eval import ImportMacros
+    Pkg3.test("ImportMacros")
 
     # Clone an registered packge and check that it can be imported
     Pkg3.clone("https://github.com/KristofferC/TimerOutputs.jl")

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -47,6 +47,14 @@ temp_pkg_dir() do project_path
     usage = Pkg3.TOML.parse(String(read(joinpath(Pkg3.logdir(), "usage.toml"))))
     @test any(x -> startswith(x, joinpath(project_path, "Manifest.toml")), keys(usage))
 
+    # Clone an unregistered packge and check that it can be imported
+    Pkg3.clone("https://github.com/fredrikekre/ImportMacros.jl")
+    @eval import ImportMacros
+
+    # Clone an registered packge and check that it can be imported
+    Pkg3.clone("https://github.com/KristofferC/TimerOutputs.jl")
+    @eval import TimerOutputs
+
     nonexisting_pkg = randstring(14)
     @test_throws CommandError Pkg3.add(nonexisting_pkg)
     @test_throws CommandError Pkg3.up(nonexisting_pkg)

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -81,7 +81,7 @@ function deps_from_data(deps_data, uuid_to_name = Dict{String,String}())
             deps[p] = Dict{VersionNumber,Available}()
         end
         if !haskey(deps[p], vn)
-            deps[p][vn] = Available("$(p)_$(vn)_sha1", Dict{String,VersionSet}())
+            deps[p][vn] = Available(Dict{String,VersionSet}())
         end
         isempty(r) && continue
         rp = uuid(r[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ else
     using Test
 end
 
-include("resolve.jl")
 include("operations.jl")
+include("resolve.jl")
 
 end # module


### PR DESCRIPTION
This is an attempt to implement `clone`. Whether this should just be called `add` with an url can easily be changed later.

Summarizing this does the following:

* The package is cloned at the master branch.
* When cloning a package, the path where the package is cloned gets written to the Manifest. We no longer write the hash because the package can be changed arbitrarily.
* If we find the name of the package in the registry, we set the version to the maximum registered.
* If the package is not registered, we give it a new random UUID, set the version to "0.0".
* For the resolver, we consider any package with a `path` to be fixed. We force the resolver to use exactly the current version of the package. Furthermore, the dependencies for a checked out package is looked up through the REQUIRE file. @carlobaldassi does that make sense? It is a bit different from how Base does it.
* `free` removes the path and we go back to the registered package.
* If the path exist where the package is supposed to be cloned to AND it looks like a package, we just point to that path, we don't upgrade the package at all. The idea is that we should never touch a package that is being developed.
* The `.travis` tests are now completely Pkg2 free. ~~To do that, I had to internalize SHA.~
* The printing has been changed to account for checked out packages: https://asciinema.org/a/zv1ahmVWdiTmrHFxikKP8o861
* I sort of accidentally changed to using the hooking system for loading packages into 0.6. I can remove that.



Some thoughts:

* The moment when the `.path` field is being assigned is pretty weird. Right now it is done when looking for dependencies for cloned packages.
* How should the UUID be generated for non registered packages. Right now, I just did generate a random one.
* The location where packages are cloned has a default and one can use an ENV variable, but a path option or something should probably be available.
* I'm using the string tokenization know where it requires quote delimited paths. This is for simplicity because I didn't wanna deal too much with the tokenizer in this PR.