### PR TITLE
Respect test only dependencies

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -369,9 +369,10 @@ mutable struct PackageSpec
     path::String
     url::String
     beingfreed::Bool # TODO: Get rid of this field
+    beingtested::Bool
     PackageSpec(name::AbstractString, uuid::UUID, version::VersionTypes, project::Symbol=:project,
-            path::AbstractString="", url::AbstractString="", beingfreed=false) =
-    new(name, uuid, version, project, path, url, beingfreed)
+            path::AbstractString="", url::AbstractString="", beingfreed=false, beingtested=false) =
+    new(name, uuid, version, project, path, url, beingfreed, beingtested)
 end
 PackageSpec(name::AbstractString, uuid::UUID) =
     PackageSpec(name, uuid, VersionSpec())
@@ -380,8 +381,8 @@ PackageSpec(name::AbstractString, version::VersionTypes=VersionSpec()) =
 PackageSpec(uuid::UUID, version::VersionTypes=VersionSpec()) =
     PackageSpec("", uuid, version)
 PackageSpec(;name::AbstractString="", uuid::UUID=UUID(zero(UInt128)), version::VersionTypes=VersionSpec(),
-            mode::Symbol=:project, path::AbstractString="", url::AbstractString="", beingfreed::Bool=false) =
-    PackageSpec(name, uuid, version, mode, path, url, beingfreed)
+            mode::Symbol=:project, path::AbstractString="", url::AbstractString="", beingfreed::Bool=false, beingtested=false) =
+    PackageSpec(name, uuid, version, mode, path, url, beingfreed, beingtested)
 
 
 has_name(pkg::PackageSpec) = !isempty(pkg.name)


### PR DESCRIPTION
This PR (built on #56, #51) makes `Pkg3.test` respect test only dependencies in `test/REQUIRE`.
Furthermore, it creates a temporary environment where the requirements for the package being tested are put into. This makes it so that if the package being tested uses Compat but fails to have that in its REQUIRE file, AND you have Compat in your current environment when testing, it will still fail. This avoids the common error of using stuff in your local environment.

The relevant commit is https://github.com/JuliaLang/Pkg3.jl/commit/a446937bc2f6b5005cbd0ee304fb1450c9a6554f.

Since the functionality of `clone` and `init` is used, there are some unnecessary info prints from these functions but we can disable that with a flag.

TODO: tests