### PR TITLE
Use import instead of Base.require in require.jl 

### DIFF
--- a/src/require.jl
+++ b/src/require.jl
@@ -1,2 +1,2 @@
 push!(empty!(LOAD_PATH), dirname(dirname(@__DIR__)))
-Base.require(:Pkg3)
+import Pkg3


### PR DESCRIPTION
Can we replace `Base.require` with `import` require.jl?, this causes problem if we want to import Pkg3 in juliarc.jl