### PR TITLE
exit pkg repl mode with ^C

### DIFF
--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -474,8 +474,6 @@ function create_mode(repl, main)
     end
 
     mk = REPL.mode_keymap(main)
-    # ^C should not exit prompt
-    delete!(mk, "^C")
 
     b = Dict{Any,Any}[
         skeymap, mk, prefix_keymap, LineEdit.history_keymap,


### PR DESCRIPTION
I find `^C` to be a convenient way to exit the pkg repl mode. That is how other repl modes behave too (help, shell, cxx etc). What was the reason for explicitly removing this?