### PR TITLE
help inference by hiding a method and not using Dates.format

### DIFF
--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -99,31 +99,40 @@ function _find_package(name::String)
     # and query the user (if we are interactive) to install it.
     @label find_global
     if isinteractive()
-        env = Types.EnvCache()
-        pkgspec = [Types.PackageSpec(base)]
-
-        r = Operations.registry_resolve!(env, pkgspec)
-        Types.has_uuid(r[1]) || return nothing
-
-        GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_INSTALL && @goto install
-        GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_ERROR   && return nothing
-
-        choice = TerminalMenus.request("Could not find package \e[1m$(base)\e[22m, do you want to install it?",
-                       TerminalMenus.RadioMenu(["yes", "yes (remember)", "no", "no (remember)"]))
-
-        if choice == 3 || choice == 4
-            choice == 4 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_ERROR)
-            return nothing
-        end
-
-        choice == 2 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_INSTALL)
-        @label install
-        Pkg3.Operations.ensure_resolved(env, pkgspec, true)
-        Pkg3.Operations.add(env, pkgspec)
-        return _find_package(name)
+        # query_if_interactive is hidden from inference
+        # since it has a significant compile cost and is not used
+        # when e.g. precompiling modules
+        return query_if_interactive[](base, name)::Union{Void, String}
+    else
+        return nothing
     end
-    return nothing
 end
 
+function _query_if_interactive(base, name)
+    env = Types.EnvCache()
+    pkgspec = [Types.PackageSpec(base)]
+
+    r = Operations.registry_resolve!(env, pkgspec)
+    Types.has_uuid(r[1]) || return nothing
+
+    GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_INSTALL && @goto install
+    GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_ERROR   && return nothing
+
+    choice = TerminalMenus.request("Could not find package \e[1m$(base)\e[22m, do you want to install it?",
+                   TerminalMenus.RadioMenu(["yes", "yes (remember)", "no", "no (remember)"]))
+
+    if choice == 3 || choice == 4
+        choice == 4 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_ERROR)
+        return nothing
+    end
+
+    choice == 2 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_INSTALL)
+    @label install
+    Pkg3.Operations.ensure_resolved(env, pkgspec, true)
+    Pkg3.Operations.add(env, pkgspec)
+    return _find_package(name)
+end
+
+const query_if_interactive = Ref{Any}(_query_if_interactive)
 
 end # module

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -100,7 +100,7 @@ function _find_package(name::String)
     @label find_global
     if isinteractive()
         # query_if_interactive is hidden from inference
-        # since it has a significant compile cost and is not used
+        # since it has a significant inference cost and is not used
         # when e.g. precompiling modules
         return query_if_interactive[](base, name)::Union{Void, String}
     else

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -559,7 +559,7 @@ function write_env_usage(manifest_file::AbstractString)
     !isfile(manifest_file) && return
     open(usage_file, "a") do io
         println(io, "[[\"", escape_string(manifest_file), "\"]]")
-        println(io, "time = ", Dates.format(now(), "YYYY-mm-ddTHH:MM:SS.sssZ"))
+        println(io, "time = ", now(), 'Z')
     end
 end
 


### PR DESCRIPTION
Dates.format is slow to infer / compile, same with all the TerminalMenus stuff.

Before PR:

JSON precompilation time: 20 sec
JSON load time: 9.2 sec

After PR:

JSON precompilation time: 9.2 sec
JSON load time: 2.0 sec

This will be needed when using this in 0.7 because this method (`_find_package`) has to be very quickly inferred.

Best looked at with whitespace off: https://github.com/JuliaLang/Pkg3.jl/pull/76/files?w=1