### PR TITLE
implement Pkg.dir() giving the path to a package in the manifest

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -228,5 +228,28 @@ function init(path = pwd())
     Pkg3.Operations.init(path)
 end
 
+dir() = error("`Pkg.dir()` is discontinued, use `Pkg.dir(\"Package\")` or `Pkg.dir([\"PackageA\", ...])`")
+
+dir(pkg::String) = dir([pkg])[1]
+function dir(pkgs_str::Vector{String})
+    env = EnvCache()
+    pkgs = [PackageSpec(pkg, :manifest) for pkg in pkgs_str]
+    manifest_resolve!(env, pkgs)
+
+    paths = String[]
+    for pkg in pkgs
+        if !has_uuid(pkg)
+            cmderror("package $pkg not found in the manifest")
+        else
+            info = manifest_info(env, pkg.uuid)
+            sha1 = SHA1(info["hash-sha1"])
+            push!(paths, Pkg3.Operations.find_installed(pkg.uuid, sha1))
+        end
+    end
+    return paths
+end
+
+
+
 end # module
 

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -49,7 +49,7 @@ include("Operations.jl")
 include("REPLMode.jl")
 include("API.jl")
 
-import .API: add, rm, up, test, gc, init
+import .API: add, rm, up, test, gc, init, dir
 const update = up
 
 function __init__()

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -459,15 +459,17 @@ mutable struct PackageSpec
     uuid::UUID
     version::VersionTypes
     mode::Symbol
-    PackageSpec(name::String, uuid::UUID, version::VersionTypes) =
-        new(name, uuid, version, :project)
 end
 PackageSpec(name::String, uuid::UUID) =
     PackageSpec(name, uuid, VersionSpec())
+PackageSpec(name::String, mode::Symbol) =
+    PackageSpec(name, UUID(zero(UInt128)), VersionSpec(), mode)
 PackageSpec(name::AbstractString, version::VersionTypes=VersionSpec()) =
     PackageSpec(name, UUID(zero(UInt128)), version)
 PackageSpec(uuid::UUID, version::VersionTypes=VersionSpec()) =
     PackageSpec("", uuid, version)
+PackageSpec(name::String, uuid::UUID, version::VersionTypes) =
+    PackageSpec(name, uuid, version, :project)
 
 has_name(pkg::PackageSpec) = !isempty(pkg.name)
 has_uuid(pkg::PackageSpec) = pkg.uuid != UUID(zero(UInt128))

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -29,6 +29,7 @@ temp_pkg_dir() do project_path
     Pkg3.add(TEST_PKG; preview = true)
     @test_warn "not in project" Pkg3.API.rm("Example")
     Pkg3.add(TEST_PKG)
+    @test isfile(joinpath(Pkg3.dir(TEST_PKG), "src", TEST_PKG * ".jl"))
     @eval import $(Symbol(TEST_PKG))
     Pkg3.up()
     Pkg3.rm(TEST_PKG; preview = true)


### PR DESCRIPTION
The same environment can't use two packages with the same name I presume?