### PR TITLE
Resolution log - looking into what the solver is doing, and why

### DIFF
--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -713,6 +713,8 @@ function log_event_eq_classes!(graph::Graph, p0::Int)
     return entry
 end
 
+showlog(graph::Graph, args...; kw...) = showlog(STDOUT, graph, args...; kw...)
+
 """
 Show the full resolution log. The `view` keyword controls how the events are displayed/grouped:
 

--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -133,7 +133,23 @@ mutable struct GraphData
 
         return data
     end
+
+    function Base.copy(data::GraphData)
+        pkgs = copy(data.pkgs)
+        np = data.np
+        spp = copy(data.spp)
+        pdict = copy(data.pdict)
+        pvers = [copy(data.pvers[p0]) for p0 = 1:np]
+        vdict = [copy(data.vdict[p0]) for p0 = 1:np]
+        uuid_to_name = copy(data.uuid_to_name)
+        pruned = copy(data.pruned)
+        eq_classes = Dict(p => copy(eq) for (p,eq) in data.eq_classes)
+        rlog = deepcopy(data.rlog)
+
+        return new(pkgs, np, spp, pdict, pvers, vdict, uuid_to_name, pruned, eq_classes, rlog)
+    end
 end
+
 
 @enum DepDir FORWARD BACKWARDS BIDIR NONE
 
@@ -303,7 +319,23 @@ mutable struct Graph
 
         return graph
     end
+
+    function Base.copy(graph::Graph)
+        data = copy(graph.data)
+        np = graph.np
+        spp = data.spp
+        gadj = [copy(graph.gadj[p0]) for p0 = 1:np]
+        gmsk = [[copy(graph.gmsk[p0][j0]) for j0 = 1:length(gadj[p0])] for p0 = 1:np]
+        gdir = [copy(graph.gdir[p0]) for p0 = 1:np]
+        gconstr = [copy(graph.gconstr[p0]) for p0 = 1:np]
+        adjdict = [copy(graph.adjdict[p0]) for p0 = 1:np]
+        req_inds = copy(graph.req_inds)
+        fix_inds = copy(graph.fix_inds)
+
+        return new(data, gadj, gmsk, gdir, gconstr, adjdict, req_inds, fix_inds, spp, np)
+    end
 end
+
 
 """
 Add explicit requirements to the graph.

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -64,7 +64,7 @@ end
 Scan the graph for (explicit or implicit) contradictions. Returns a list of problematic
 (package,version) combinations.
 """
-function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}())
+function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}(); verbose = true)
     req_inds = graph.req_inds
     fix_inds = graph.fix_inds
 
@@ -107,8 +107,18 @@ function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}())
 
     checked = falses(nv)
 
+    last_str_len = 0
+
     i = 1
     for (p,vn) in vers
+        if verbose
+            frac_compl = i / nv
+            print("\r", " "^last_str_len)
+            progr_msg = @sprintf("\r%.3i/%.3i (%i%%) — problematic so far: %i", i, nv, round(Int, 100 * frac_compl), length(problematic))
+            print(progr_msg)
+            last_str_len = length(progr_msg)
+        end
+
         length(gadj[pdict[p]]) == 0 && break
         checked[i] && (i += 1; continue)
 
@@ -156,6 +166,7 @@ function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}())
 
         i += 1
     end
+    verbose && println()
 
     return sort!(problematic)
 end

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -32,16 +32,11 @@ function resolve(graph::Graph; verbose::Bool = false)
     catch err
         isa(err, UnsatError) || rethrow(err)
         verbose && info("resolve: maxsum failed")
-        p = graph.data.pkgs[err.info]
+        # p = graph.data.pkgs[err.info]
         # TODO: build tools to analyze the problem, and suggest to use them here.
         msg =
             """
             resolve is unable to satisfy package requirements.
-              The problem was detected when trying to find a feasible version
-              for package $(id(p)).
-              However, this only means that package $(id(p)) is involved in an
-              unsatisfiable or difficult dependency relation, and the root of
-              the problem may be elsewhere.
             """
         if msgs.num_nondecimated != graph.np
             msg *= """

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -117,8 +117,8 @@ function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}(); verbose::B
         length(gadj[pdict[p]]) == 0 && break
         checked[i] && (i += 1; continue)
 
-        sub_graph = deepcopy(graph)
         req = Requires(p => vn)
+        sub_graph = copy(graph)
         add_reqs!(sub_graph, req)
 
         try

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -176,6 +176,15 @@ function Base.convert(::Type{VersionRange}, s::AbstractString)
     return VersionRange(lower, upper)
 end
 
+Base.print(io::IO, r::VersionRange{0,0}) = print(io, '*')
+function Base.print(io::IO, r::VersionRange{0,n}) where {n}
+    print(io, "0-")
+    join(io, r.upper.t, '.')
+end
+function Base.print(io::IO, r::VersionRange{m,0}) where {m}
+    join(io, r.lower.t, '.')
+    print(io, "-*")
+end
 function Base.print(io::IO, r::VersionRange)
     join(io, r.lower.t, '.')
     if r.lower != r.upper
@@ -183,7 +192,6 @@ function Base.print(io::IO, r::VersionRange)
         join(io, r.upper.t, '.')
     end
 end
-Base.print(io::IO, ::VersionRange{0,0}) = print(io, "*")
 Base.show(io::IO, r::VersionRange) = print(io, "VersionRange(\"", r, "\")")
 
 Base.in(v::VersionNumber, r::VersionRange) = r.lower ≲ v ≲ r.upper

--- a/src/resolve/MaxSum.jl
+++ b/src/resolve/MaxSum.jl
@@ -11,7 +11,7 @@ export UnsatError, Messages, maxsum
 # An exception type used internally to signal that an unsatisfiable
 # constraint was detected
 struct UnsatError <: Exception
-    info
+    trace
 end
 
 # Some parameters to drive the decimation process

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -197,9 +197,10 @@ function resolve_tst(deps_data, reqs_data, want_data = nothing)
     simplify_graph!(graph)
     want = resolve(graph)
 
-    # info(sprint(io->showlog(io, graph)))
+    # rlog = get_resolve_log(graph)
+    # info(sprint(io->showlog(io, rlog)))
     # println()
-    # info(sprint(io->showlog(io, graph, view=:chronological)))
+    # info(sprint(io->showlog(io, rlog, view=:chronological)))
 
     return want == wantuuids(want_data)
 end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -172,7 +172,7 @@ function sanity_tst(deps_data, expected_result; pkgs=[])
         @show deps_data
         @show pkgs
     end
-    result = sanity_check(graph, Set(pkguuid(p) for p in pkgs), verbose = VERBOSE)
+    result = sanity_check(graph, Set(pkguuid(p) for p in pkgs))
 
     length(result) == length(expected_result) || return false
     expected_result_uuid = [(id(p), vn) for (p,vn) in expected_result]
@@ -194,8 +194,8 @@ function resolve_tst(deps_data, reqs_data, want_data = nothing)
     reqs = reqs_from_data(reqs_data, graph)
     add_reqs!(graph, reqs)
 
-    simplify_graph!(graph, verbose = VERBOSE)
-    want = resolve(graph, verbose = VERBOSE)
+    simplify_graph!(graph)
+    want = resolve(graph)
 
     # info(sprint(io->showlog(io, graph)))
     # println()

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -197,7 +197,9 @@ function resolve_tst(deps_data, reqs_data, want_data = nothing)
     simplify_graph!(graph, verbose = VERBOSE)
     want = resolve(graph, verbose = VERBOSE)
 
-    # info("BACKTRACE:\n" * sprint(showbacktrace, graph))
+    # info(sprint(io->showlog(io, graph)))
+    # println()
+    # info(sprint(io->showlog(io, graph, view=:chronological)))
 
     return want == wantuuids(want_data)
 end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -197,6 +197,8 @@ function resolve_tst(deps_data, reqs_data, want_data = nothing)
     simplify_graph!(graph, verbose = VERBOSE)
     want = resolve(graph, verbose = VERBOSE)
 
+    # info("BACKTRACE:\n" * sprint(showbacktrace, graph))
+
     return want == wantuuids(want_data)
 end
 
@@ -329,6 +331,7 @@ VERBOSE && info("SCHEME 5")
 deps_data = Any[
     ["A", v"1", "B", "2-*"],
     ["A", v"1", "C", "2-*"],
+    # ["A", v"1", "julia", "10"],
     ["A", v"2", "B", "1"],
     ["A", v"2", "C", "1"],
     ["B", v"1", "C", "2-*"],

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -172,7 +172,7 @@ function sanity_tst(deps_data, expected_result; pkgs=[])
         @show deps_data
         @show pkgs
     end
-    result = sanity_check(graph, Set(pkguuid(p) for p in pkgs))
+    result = sanity_check(graph, Set(pkguuid(p) for p in pkgs), verbose = VERBOSE)
 
     length(result) == length(expected_result) || return false
     expected_result_uuid = [(id(p), vn) for (p,vn) in expected_result]


### PR DESCRIPTION
(This is done on top of #83. I guess I could rebase it on top of #81 instead if the review of cloning/freeing needs more time.)

This greatly improves the ability to see what `resolve` does. Examples are at the bottom. Essentially, it logs everything. In case of errors, the log is represented in tree form, starting from the package with unsatisfiable conditions, like before. Otherwise, in case of success, the full log can be seen in different ways - the tree view, a plain view in which events are grouped by package, and a chronological view which shows a journal. This can very well be the basis for a "why" API command if the user wants to understand why some package is not getting updated etc. (or something along those lines). Cf. https://github.com/JuliaLang/julia/issues/13340 (cc @vtjnash).

Note that the cryptic messages about "mysterious", unspecified difficult dependencies is gone. This one:
```
"""
resolve is unable to satisfy package requirements.
  The problem was detected when trying to find a feasible version
  for package $p.
  However, this only means that package $p is involved in an
  unsatisfiable or difficult dependency relation, and the root of
  the problem may be elsewhere.
"""
```
Instead, the solver tries to get to the bottom of the matter. The starting point is still the heuristic, so this can be improved (and it will be), but I have tried *really* hard to find some problematic situations with the packages in the current Uncurated registry and couldn't find any (I decided I'll have to resort to artificially generated nasty problem instances). Incidentally, I have also improved a tiny bit the heuristic solver.

Also, the log can be detached and passed around/displayed/saved to a file etc., independently of the `Graph` it came from.

One thing I'd like to add probably is some filtering functionality to the log display.

Another thing which is kind of annoying is that many log lines are long, and something like https://github.com/carlobaldassi/TextWrap.jl would be required to make them nicer, especially in the tree view. But then it would need to get into the stdlib.

--------------

Example of a resolve log in plain/group format, with test package names `A`, `B`, ..., `F`:

```
INFO: Resolve log:
 Global events:
 ├─propagating constraints
 ├─disabling unreachable nodes
 ├─pruned graph — stats (n. of packages, mean connectivity): before = (7,2.857142857142857) after = (0,NaN)
 ├─computing version equivalence classes
 ├─computed version equivalence classes, stats (total n. of states): before = 0 after = 0
 └─the solver found a feasible configuration
 A [77b1b708] log:
 ├─possible versions are: [1.0.0, 2.0.0, 3.0.0] or uninstalled
 ├─restricted by compatibility requirements with B [68f2bcc9] to versions: 1.0.0
 └─fixed during graph pruning to its only remaining available version, 1.0.0
 B [68f2bcc9] log:
 ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
 ├─restricted to versions 1 by an explicit requirement, leaving only versions 1.0.0
 └─fixed during graph pruning to its only remaining available version, 1.0.0
 C [26154a1f] log:
 ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
 ├─restricted by compatibility requirements with A [77b1b708] to versions: uninstalled
 └─determined to be unneeded during graph pruning
 D [b8ca0a3d] log:
 ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
 ├─restricted by compatibility requirements with B [68f2bcc9] to versions: 1.0.0 or uninstalled
 ├─restricted by compatibility requirements with E [fcc56117] to versions: [1.0.0, 2.0.0], leaving only versions: 1.0.0
 └─fixed during graph pruning to its only remaining available version, 1.0.0
 E [fcc56117] log:
 ├─possible versions are: 1.0.0 or uninstalled
 ├─restricted by compatibility requirements with F [8f5fc5d0] to versions: 1.0.0
 └─fixed during graph pruning to its only remaining available version, 1.0.0
 F [8f5fc5d0] log:
 ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
 ├─restricted to versions * by an explicit requirement, leaving only versions [1.0.0, 2.0.0]
 ├─restricted by compatibility requirements with C [26154a1f] to versions: 1.0.0 or uninstalled, leaving only versions: 1.0.0
 └─fixed during graph pruning to its only remaining available version, 1.0.0
```

And the same thing in chronological order:
```
INFO: Resolve log:
 C [26154a1f]  : possible versions are: [1.0.0, 2.0.0] or uninstalled
 B [68f2bcc9]  : possible versions are: [1.0.0, 2.0.0] or uninstalled
 A [77b1b708]  : possible versions are: [1.0.0, 2.0.0, 3.0.0] or uninstalled
 F [8f5fc5d0]  : possible versions are: [1.0.0, 2.0.0] or uninstalled
 D [b8ca0a3d]  : possible versions are: [1.0.0, 2.0.0] or uninstalled
 E [fcc56117]  : possible versions are: 1.0.0 or uninstalled
 B [68f2bcc9]  : restricted to versions 1 by an explicit requirement, leaving only versions 1.0.0
 F [8f5fc5d0]  : restricted to versions * by an explicit requirement, leaving only versions [1.0.0, 2.0.0]
 [global event]: propagating constraints
 A [77b1b708]  : restricted by compatibility requirements with B [68f2bcc9] to versions: 1.0.0
 D [b8ca0a3d]  : restricted by compatibility requirements with B [68f2bcc9] to versions: 1.0.0 or uninstalled
 E [fcc56117]  : restricted by compatibility requirements with F [8f5fc5d0] to versions: 1.0.0
 D [b8ca0a3d]  : restricted by compatibility requirements with E [fcc56117] to versions: [1.0.0, 2.0.0], leaving only versions: 1.0.0
 C [26154a1f]  : restricted by compatibility requirements with A [77b1b708] to versions: uninstalled
 F [8f5fc5d0]  : restricted by compatibility requirements with C [26154a1f] to versions: 1.0.0 or uninstalled, leaving only versions: 1.0.0
 [global event]: disabling unreachable nodes
 C [26154a1f]  : determined to be unneeded during graph pruning
 B [68f2bcc9]  : fixed during graph pruning to its only remaining available version, 1.0.0
 A [77b1b708]  : fixed during graph pruning to its only remaining available version, 1.0.0
 F [8f5fc5d0]  : fixed during graph pruning to its only remaining available version, 1.0.0
 D [b8ca0a3d]  : fixed during graph pruning to its only remaining available version, 1.0.0
 E [fcc56117]  : fixed during graph pruning to its only remaining available version, 1.0.0
 [global event]: pruned graph — stats (n. of packages, mean connectivity): before = (7,2.857142857142857) after = (0,NaN)
 [global event]: computing version equivalence classes
 [global event]: computed version equivalence classes, stats (total n. of states): before = 0 after = 0
 [global event]: the solver found a feasible configuration
```

This is a simple error instead:
```
ERROR: Unsatisfiable requirements detected for package B [68f2bcc9]:
 B [68f2bcc9] log:
 ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
 ├─restricted by compatibility requirements with A [77b1b708] to versions: 1.0.0
 │ └─A [77b1b708] log:
 │   ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
 │   └─restricted to versions 2-* by an explicit requirement, leaving only versions 2.0.0
 └─restricted by compatibility requirements with C [26154a1f] to versions: uninstalled — no versions left
   └─C [26154a1f] log:
     ├─possible versions are: [1.0.0, 2.0.0] or uninstalled
     └─restricted by compatibility requirements with A [77b1b708] to versions: 1.0.0
       └─A [77b1b708] log: see above
```

And this is a much more complicated error:
```
julia-0.6> Pkg3.add(["ForwardDiff","ReverseDiff","Latexify","VehicleModels"])
INFO: Resolving package versions
ERROR: Unsatisfiable requirements detected for package Latexify [23fbe1c1]:
 Latexify [23fbe1c1] log:
 ├─possible versions are: [0.0.1, 0.1.0] or uninstalled
 ├─restricted to versions * by an explicit requirement, leaving only versions [0.0.1, 0.1.0]
 ├─restricted by compatibility requirements with DifferentialEquations [0c46a032] to versions: 0.1.0 or uninstalled, leaving only versions: 0.1.0
 │ └─DifferentialEquations [0c46a032] log:
 │   ├─possible versions are: [0.0.1-0.0.3, 0.1.0-0.1.4, 0.2.0-0.2.1, 0.3.0, 0.4.0-0.4.2, 0.5.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0-1.9.1, 1.10.0-1.10.1, 2.0.0, 2.1.0, 2.2.0-2.2.1, 2.3.0, 3.0.0-3.0.2] or uninstalled
 │   ├─restricted by julia compatibility requirements to versions: [0.4.0-0.4.2, 0.5.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0-1.9.1, 1.10.0-1.10.1, 2.0.0, 2.1.0, 2.2.0-2.2.1, 2.3.0, 3.0.0-3.0.2] or uninstalled
 │   └─restricted by compatibility requirements with StochasticDiffEq [789caeaf] to versions: [0.0.1-0.0.3, 0.1.0-0.1.4, 0.2.0-0.2.1, 0.3.0, 0.4.0-0.4.2, 0.5.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0-1.9.1, 1.10.0-1.10.1, 2.0.0, 2.1.0, 2.2.0-2.2.1] or uninstalled, leaving only versions: [0.4.0-0.4.2, 0.5.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0-1.9.1, 1.10.0-1.10.1, 2.0.0, 2.1.0, 2.2.0-2.2.1] or uninstalled
 │     └─StochasticDiffEq [789caeaf] log:
 │       ├─possible versions are: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0, 0.3.0, 0.4.0, 0.5.0, 1.0.0-1.0.2, 1.1.0, 1.2.0-1.2.1, 1.3.0, 1.4.0, 2.0.0-2.0.4, 2.1.0, 2.2.0-2.2.1, 2.3.0, 2.4.0, 2.5.0-2.5.1, 2.6.0, 2.7.0-2.7.1, 2.8.0, 2.9.0-2.9.1, 2.10.0, 2.11.0-2.11.1, 2.12.0-2.12.1, 2.13.0-2.13.1, 2.14.0, 2.15.0-2.15.2, 2.16.0, 2.17.0, 2.18.0-2.18.1, 2.19.0] or uninstalled
 │       ├─restricted by compatibility requirements with ForwardDiff [f6369f11] to versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0, 0.3.0, 0.4.0, 0.5.0, 1.0.0-1.0.2, 1.1.0, 1.2.0-1.2.1, 1.3.0, 1.4.0, 2.0.0-2.0.4, 2.1.0, 2.2.0-2.2.1, 2.12.0-2.12.1, 2.13.0-2.13.1, 2.14.0, 2.15.0-2.15.2, 2.16.0, 2.17.0, 2.18.0-2.18.1, 2.19.0] or uninstalled
 │       │ └─ForwardDiff [f6369f11] log:
 │       │   ├─possible versions are: [0.0.2-0.0.3, 0.1.0-0.1.8, 0.2.0-0.2.5, 0.3.0-0.3.5, 0.4.0-0.4.2, 0.5.0, 0.6.0, 0.7.0] or uninstalled
 │       │   ├─restricted to versions * by an explicit requirement, leaving only versions [0.0.2-0.0.3, 0.1.0-0.1.8, 0.2.0-0.2.5, 0.3.0-0.3.5, 0.4.0-0.4.2, 0.5.0, 0.6.0, 0.7.0]
 │       │   ├─restricted by compatibility requirements with ReverseDiff [37e2e3b7] to versions: [0.3.2-0.3.5, 0.4.0-0.4.2, 0.6.0, 0.7.0]
 │       │   │ └─ReverseDiff [37e2e3b7] log:
 │       │   │   ├─possible versions are: [0.0.1-0.0.4, 0.1.0-0.1.2, 0.1.4-0.1.5, 0.2.0] or uninstalled
 │       │   │   ├─restricted to versions * by an explicit requirement, leaving only versions [0.0.1-0.0.4, 0.1.0-0.1.2, 0.1.4-0.1.5, 0.2.0]
 │       │   │   └─restricted by compatibility requirements with ForwardDiff [f6369f11] to versions: [0.0.1-0.0.4, 0.1.0-0.1.2, 0.1.4-0.1.5] or uninstalled, leaving only versions: [0.0.1-0.0.4, 0.1.0-0.1.2, 0.1.4-0.1.5]
 │       │   │     └─ForwardDiff [f6369f11] log: see above
 │       │   ├─restricted by julia compatibility requirements to versions: [0.1.3-0.1.8, 0.2.0-0.2.5, 0.3.0-0.3.4, 0.4.0-0.4.2, 0.5.0, 0.6.0, 0.7.0] or uninstalled, leaving only versions: [0.3.2-0.3.4, 0.4.0-0.4.2, 0.6.0, 0.7.0]
 │       │   ├─restricted by compatibility requirements with OrdinaryDiffEq [1dea7af3] to versions: [0.2.4-0.2.5, 0.3.0-0.3.5, 0.4.0-0.4.2, 0.7.0], leaving only versions: [0.3.2-0.3.4, 0.4.0-0.4.2, 0.7.0]
 │       │   │ └─OrdinaryDiffEq [1dea7af3] log:
 │       │   │   ├─possible versions are: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0-0.2.1, 0.3.0-0.3.1, 0.4.0-0.4.2, 0.5.0, 0.6.0, 1.0.0-1.0.2, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0-1.4.1, 1.5.0, 1.6.0-1.6.1, 1.7.0, 1.8.0, 2.0.0-2.0.3, 2.1.0, 2.2.0-2.2.1, 2.3.1-2.3.2, 2.4.0, 2.5.0, 2.6.0-2.6.1, 2.7.0-2.7.1, 2.8.0, 2.9.0, 2.10.0, 2.11.0-2.11.3, 2.12.0, 2.13.0, 2.14.0, 2.15.0, 2.16.0, 2.17.0, 2.18.0, 2.19.0-2.19.1, 2.20.0, 2.21.0-2.21.2, 2.22.0, 2.23.0, 2.24.0-2.24.1, 2.25.0-2.25.2, 2.26.0, 2.27.0, 2.28.0, 2.29.0-2.29.1, 2.30.0] or uninstalled
 │       │   │   ├─restricted by compatibility requirements with ForwardDiff [f6369f11] to versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0-0.2.1, 0.3.0-0.3.1, 0.4.0-0.4.2, 0.5.0, 0.6.0, 1.0.0-1.0.2, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0-1.4.1, 1.5.0, 1.6.0-1.6.1, 1.7.0, 1.8.0, 2.0.0-2.0.3, 2.1.0, 2.2.0-2.2.1, 2.3.1-2.3.2, 2.4.0, 2.27.0, 2.28.0, 2.29.0-2.29.1, 2.30.0] or uninstalled
 │       │   │   │ └─ForwardDiff [f6369f11] log: see above
 │       │   │   ├─restricted by compatibility requirements with VehicleModels [c05f3a35] to versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0-0.2.1, 0.3.0-0.3.1, 0.4.0-0.4.2, 0.5.0, 0.6.0, 1.0.0-1.0.2, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0-1.4.1, 1.5.0, 1.6.0-1.6.1, 1.7.0, 1.8.0, 2.0.0-2.0.3, 2.1.0, 2.2.0-2.2.1, 2.3.1-2.3.2, 2.4.0, 2.5.0, 2.6.0-2.6.1, 2.7.0-2.7.1, 2.8.0, 2.9.0, 2.10.0, 2.11.0-2.11.3, 2.12.0, 2.13.0, 2.14.0, 2.15.0, 2.16.0, 2.17.0, 2.18.0, 2.19.0-2.19.1, 2.20.0, 2.21.0-2.21.2, 2.22.0, 2.23.0, 2.24.0-2.24.1, 2.25.0-2.25.2, 2.26.0, 2.27.0, 2.28.0, 2.29.0-2.29.1, 2.30.0], leaving only versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0-0.2.1, 0.3.0-0.3.1, 0.4.0-0.4.2, 0.5.0, 0.6.0, 1.0.0-1.0.2, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0-1.4.1, 1.5.0, 1.6.0-1.6.1, 1.7.0, 1.8.0, 2.0.0-2.0.3, 2.1.0, 2.2.0-2.2.1, 2.3.1-2.3.2, 2.4.0, 2.27.0, 2.28.0, 2.29.0-2.29.1, 2.30.0]
 │       │   │   │ └─VehicleModels [c05f3a35] log:
 │       │   │   │   ├─possible versions are: 0.1.2-0.1.3 or uninstalled
 │       │   │   │   └─restricted to versions * by an explicit requirement, leaving only versions 0.1.2-0.1.3
 │       │   │   └─restricted by compatibility requirements with ForwardDiff [f6369f11] to versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0-0.2.1, 0.3.0-0.3.1, 0.4.0-0.4.2, 0.5.0, 0.6.0, 1.0.0-1.0.2, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0-1.4.1, 1.5.0, 1.6.0-1.6.1, 1.7.0, 1.8.0, 2.0.0-2.0.3, 2.1.0, 2.2.0-2.2.1, 2.3.1-2.3.2, 2.4.0] or uninstalled, leaving only versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0-0.2.1, 0.3.0-0.3.1, 0.4.0-0.4.2, 0.5.0, 0.6.0, 1.0.0-1.0.2, 1.1.0, 1.2.0, 1.3.0-1.3.1, 1.4.0-1.4.1, 1.5.0, 1.6.0-1.6.1, 1.7.0, 1.8.0, 2.0.0-2.0.3, 2.1.0, 2.2.0-2.2.1, 2.3.1-2.3.2, 2.4.0]
 │       │   │     └─ForwardDiff [f6369f11] log: see above
 │       │   └─restricted by compatibility requirements with JuMP [4076af6c] to versions: [0.3.0-0.3.5, 0.4.0-0.4.2], leaving only versions: [0.3.2-0.3.4, 0.4.0-0.4.2]
 │       │     └─JuMP [4076af6c] log:
 │       │       ├─possible versions are: [0.1.1-0.1.2, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0-0.5.8, 0.6.0-0.6.3, 0.7.0-0.7.4, 0.8.0, 0.9.0-0.9.3, 0.10.0-0.10.3, 0.11.0-0.11.3, 0.12.0-0.12.2, 0.13.0-0.13.2, 0.14.0-0.14.2, 0.15.0-0.15.1, 0.16.0-0.16.2, 0.17.0-0.17.1, 0.18.0] or uninstalled
 │       │       ├─restricted by compatibility requirements with ForwardDiff [f6369f11] to versions: [0.1.1-0.1.2, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0-0.5.8, 0.6.0-0.6.3, 0.7.0-0.7.4, 0.8.0, 0.9.0-0.9.3, 0.10.0-0.10.3, 0.11.0-0.11.3, 0.15.0-0.15.1, 0.16.0-0.16.2, 0.17.0-0.17.1] or uninstalled
 │       │       │ └─ForwardDiff [f6369f11] log: see above
 │       │       ├─restricted by compatibility requirements with VehicleModels [c05f3a35] to versions: [0.1.1-0.1.2, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0-0.5.8, 0.6.0-0.6.3, 0.7.0-0.7.4, 0.8.0, 0.9.0-0.9.3, 0.10.0-0.10.3, 0.11.0-0.11.3, 0.12.0-0.12.2, 0.13.0-0.13.2, 0.14.0-0.14.2, 0.15.0-0.15.1, 0.16.0-0.16.2, 0.17.0-0.17.1, 0.18.0], leaving only versions: [0.1.1-0.1.2, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0-0.5.8, 0.6.0-0.6.3, 0.7.0-0.7.4, 0.8.0, 0.9.0-0.9.3, 0.10.0-0.10.3, 0.11.0-0.11.3, 0.15.0-0.15.1, 0.16.0-0.16.2, 0.17.0-0.17.1]
 │       │       │ └─VehicleModels [c05f3a35] log: see above
 │       │       └─restricted by julia compatibility requirements to versions: [0.13.2, 0.14.0-0.14.2, 0.15.0-0.15.1, 0.16.0-0.16.2, 0.17.0-0.17.1, 0.18.0] or uninstalled, leaving only versions: [0.15.0-0.15.1, 0.16.0-0.16.2, 0.17.0-0.17.1]
 │       ├─restricted by compatibility requirements with DiffEqBase [2b5f629d] to versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0, 0.3.0, 0.4.0, 0.5.0, 1.0.0-1.0.2, 1.1.0, 1.2.0-1.2.1, 1.3.0, 1.4.0, 2.0.0-2.0.4, 2.1.0, 2.2.0-2.2.1, 2.3.0, 2.4.0, 2.5.0-2.5.1, 2.6.0, 2.7.0-2.7.1, 2.13.0-2.13.1, 2.14.0, 2.15.0-2.15.2, 2.16.0, 2.17.0, 2.18.0-2.18.1, 2.19.0] or uninstalled, leaving only versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0, 0.3.0, 0.4.0, 0.5.0, 1.0.0-1.0.2, 1.1.0, 1.2.0-1.2.1, 1.3.0, 1.4.0, 2.0.0-2.0.4, 2.1.0, 2.2.0-2.2.1, 2.13.0-2.13.1, 2.14.0, 2.15.0-2.15.2, 2.16.0, 2.17.0, 2.18.0-2.18.1, 2.19.0] or uninstalled
 │       │ └─DiffEqBase [2b5f629d] log:
 │       │   ├─possible versions are: [0.0.1-0.0.4, 0.1.0-0.1.3, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0-0.12.1, 0.13.0, 0.14.0, 0.15.0, 1.0.0-1.0.2, 1.1.0-1.1.2, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0-1.5.1, 1.6.0-1.6.1, 1.7.0, 1.8.0-1.8.1, 1.9.0, 1.10.0-1.10.2, 1.11.0, 1.12.0, 1.13.0, 1.14.0-1.14.1, 1.15.0-1.15.1, 1.16.0, 1.17.0, 1.18.0-1.18.1, 1.19.0, 1.20.0, 1.21.0, 1.22.0, 1.23.0-1.23.1, 1.24.0-1.24.1, 2.0.0, 2.1.0, 2.2.0, 2.3.0-2.3.3, 2.4.0, 2.5.0, 2.6.0] or uninstalled
 │       │   ├─restricted by compatibility requirements with VehicleModels [c05f3a35] to versions: [0.0.1-0.0.4, 0.1.0-0.1.3, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0-0.12.1, 0.13.0, 0.14.0, 0.15.0, 1.0.0-1.0.2, 1.1.0-1.1.2, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0-1.5.1, 1.6.0-1.6.1, 1.7.0, 1.8.0-1.8.1, 1.9.0, 1.10.0-1.10.2, 1.11.0, 1.12.0, 1.13.0, 1.14.0-1.14.1, 1.15.0-1.15.1, 1.16.0, 1.17.0, 1.18.0-1.18.1, 1.19.0, 1.20.0, 1.21.0, 1.22.0, 1.23.0-1.23.1, 1.24.0-1.24.1, 2.0.0, 2.1.0, 2.2.0, 2.3.0-2.3.3, 2.4.0, 2.5.0, 2.6.0]
 │       │   │ └─VehicleModels [c05f3a35] log: see above
 │       │   ├─restricted by compatibility requirements with OrdinaryDiffEq [1dea7af3] to versions: [0.0.1-0.0.4, 0.1.0-0.1.3, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0-0.12.1, 0.13.0, 0.14.0, 0.15.0, 1.0.0-1.0.2, 1.1.0-1.1.2, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0-1.5.1, 1.6.0-1.6.1, 1.7.0, 1.8.0-1.8.1, 1.9.0, 1.10.0-1.10.2, 1.11.0, 1.12.0, 1.13.0, 1.14.0-1.14.1, 2.4.0, 2.5.0, 2.6.0]
 │       │   │ └─OrdinaryDiffEq [1dea7af3] log: see above
 │       │   └─restricted by compatibility requirements with OrdinaryDiffEq [1dea7af3] to versions: [0.0.1-0.0.4, 0.1.0-0.1.3, 0.2.0, 0.3.0-0.3.2, 0.4.0-0.4.1, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0-0.12.1, 0.13.0, 0.14.0, 0.15.0, 1.0.0-1.0.2, 1.1.0-1.1.2, 1.2.0, 1.3.0-1.3.1, 1.4.0, 1.5.0-1.5.1, 1.6.0-1.6.1, 1.7.0, 1.8.0-1.8.1, 1.9.0, 1.10.0-1.10.2, 1.11.0, 1.12.0, 1.13.0, 1.14.0-1.14.1]
 │       │     └─OrdinaryDiffEq [1dea7af3] log: see above
 │       └─restricted by compatibility requirements with ForwardDiff [f6369f11] to versions: [0.0.1-0.0.5, 0.1.0-0.1.1, 0.2.0, 0.3.0, 0.4.0, 0.5.0, 1.0.0-1.0.2, 1.1.0, 1.2.0-1.2.1, 1.3.0, 1.4.0, 2.0.0-2.0.4, 2.1.0, 2.2.0-2.2.1] or uninstalled
 │         └─ForwardDiff [f6369f11] log: see above
 └─restricted by compatibility requirements with DiffEqBase [2b5f629d] to versions: 0.0.1 or uninstalled — no versions left
   └─DiffEqBase [2b5f629d] log: see above
```