### PR TITLE
Support for packages with same UUID(and same name) in multiple registries

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1032,10 +1032,10 @@ function registered_uuid(env::EnvCache, name::String)::UUID
     choices_cache::Vector{Tuple{UUID, String}} = []
                          
     for uuid in uuids
-        values = my_registered_info(env, uuid, "repo")
+        values = registered_info(env, uuid, "repo")
         for value in values
             push!(choices, "Registry: $(split(value[1],"/")[end-2]) - Path:$(value[2])")
-            push!(choices_cache, Pair(uuid, value[1]))
+            push!(choices_cache, (uuid, value[1]))
         end
     end   
     length(choices_cache) == 1 && return choice_cache[1][1]

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1039,13 +1039,12 @@ function registered_uuid(env::EnvCache, name::String)::UUID
         end
     end
     length(choices_cache) == 1 && return choices_cache[1][1]
-    
     # prompt for which UUID was intended:
     menu = RadioMenu(choices)
     choice = request("There are multiple registered `$name` packages, choose one:", menu)
     choice == -1 && return UUID(zero(UInt128))
-    env.paths[choice_cache[choice][1]] = [choice_cache[choice][2]]
-    return choice_cache[choice][1]
+    env.paths[choices_cache[choice][1]] = [choices_cache[choice][2]]
+    return choices_cache[choice][1]
 end
 
 "Determine current name for a given package UUID"
@@ -1053,8 +1052,12 @@ function registered_name(env::EnvCache, uuid::UUID)::String
     names = registered_names(env, uuid)
     length(names) == 0 && return ""
     length(names) == 1 && return names[1]
-    name = distinct(registered_info(env, uuid, "name"))
-    name > 1 && cmderror("package `$uuid` has multiple registered names values: ", join(values, ", "))
+    values = registered_info(env, uuid, "name")
+    name = nothing
+    for value in values
+        name  == nothing && (name = value[2])
+        name != value[2] && cmderror("package `$uuid` has multiple registered name values: $name, $(value[2])")
+    end
     return name
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1009,7 +1009,7 @@ find_registered!(env::EnvCache)::Void =
 "Get registered uuids associated with a package name"
 function registered_uuids(env::EnvCache, name::String)::Vector{UUID}
     find_registered!(env, [name], UUID[])
-    return env.uuids[name]
+    return unique(env.uuids[name])
 end
 
 "Get registered paths associated with a package uuid"
@@ -1026,7 +1026,7 @@ end
 
 "Determine a single UUID for a given name, prompting if needed"
 function registered_uuid(env::EnvCache, name::String)::UUID
-    uuids = unique(registered_uuids(env, name))
+    uuids = registered_uuids(env, name)
     length(uuids) == 0 && return UUID(zero(UInt128))
     choices::Vector{String} = []
     choices_cache::Vector{Tuple{UUID, String}} = [] 
@@ -1068,7 +1068,7 @@ function registered_info(env::EnvCache, uuid::UUID, key::String)
     for path in paths
         info = parse_toml(path, "package.toml")
         value = get(info, key, nothing)
-        push!(values, (path,value)) 
+        push!(values, (path, value)) 
     end
     return values
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1053,7 +1053,9 @@ function registered_name(env::EnvCache, uuid::UUID)::String
     names = registered_names(env, uuid)
     length(names) == 0 && return ""
     length(names) == 1 && return names[1]
-    return registered_info(env, uuid, "name")
+    name = distinct(registered_info(env, uuid, "name"))
+    name > 1 && cmderror("package `$uuid` has multiple registered names values: ", join(values, ", "))
+    return name
 end
 
 "Return most current package info for a registered UUID"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1029,8 +1029,7 @@ function registered_uuid(env::EnvCache, name::String)::UUID
     uuids = unique(registered_uuids(env, name))
     length(uuids) == 0 && return UUID(zero(UInt128))
     choices::Vector{String} = []
-    choices_cache::Vector{Tuple{UUID, String}} = []
-    
+    choices_cache::Vector{Tuple{UUID, String}} = [] 
     for uuid in uuids
         values = registered_info(env, uuid, "repo")
         for value in values
@@ -1065,7 +1064,7 @@ end
 function registered_info(env::EnvCache, uuid::UUID, key::String)
     paths = env.paths[uuid]
     isempty(paths) && cmderror("`$uuid` is not registered")
-    values::Vector{Tuple{String, String}} = []
+    values = []
     for path in paths
         info = parse_toml(path, "package.toml")
         value = get(info, key, nothing)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1030,15 +1030,15 @@ function registered_uuid(env::EnvCache, name::String)::UUID
     length(uuids) == 0 && return UUID(zero(UInt128))
     choices::Vector{String} = []
     choices_cache::Vector{Tuple{UUID, String}} = []
-                         
+    
     for uuid in uuids
         values = registered_info(env, uuid, "repo")
         for value in values
-            push!(choices, "Registry: $(split(value[1],"/")[end-2]) - Path:$(value[2])")
+            push!(choices, "Registry: $(split(value[1],"/")[end-2]) - Path: $(value[2])")
             push!(choices_cache, (uuid, value[1]))
         end
-    end   
-    length(choices_cache) == 1 && return choice_cache[1][1]
+    end
+    length(choices_cache) == 1 && return choices_cache[1][1]
     
     # prompt for which UUID was intended:
     menu = RadioMenu(choices)
@@ -1062,7 +1062,7 @@ function registered_info(env::EnvCache, uuid::UUID, key::String)
     isempty(paths) && cmderror("`$uuid` is not registered")
     values::Vector{Pair{String, String}} = []
     for path in paths
-        info = parse_toml(paths[1], "package.toml")
+        info = parse_toml(path, "package.toml")
         value = get(info, key, nothing)
         push!(values,  Pair(path,value)) 
     end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1062,11 +1062,11 @@ end
 function registered_info(env::EnvCache, uuid::UUID, key::String)
     paths = env.paths[uuid]
     isempty(paths) && cmderror("`$uuid` is not registered")
-    values::Vector{Pair{String, String}} = []
+    values::Vector{Tuple{String, String}} = []
     for path in paths
         info = parse_toml(path, "package.toml")
         value = get(info, key, nothing)
-        push!(values,  Pair(path,value)) 
+        push!(values, (path,value)) 
     end
     return values
 end


### PR DESCRIPTION
Packages(with same name and uuid) can exist in two different registries, where package in one is behind the other.

Example:
Package 'Actors' with different versions(same UUID), v0.0.1 in MyRegistry and v0.1.0 in Uncurated.  
```
julia> import Pkg3

pkg> add Actors
There are multiple registered `Actors` packages, choose one:
 > Registry: MyRegistry - Path: https://github.com/daqcore/Actors.jl.git
   Registry: Uncurated - Path: https://github.com/daqcore/Actors.jl.git
INFO: Resolving package versions
INFO: Updating "~/.julia/environments/v0.6/Project.toml"
 [1c4bc1b3] + Actors v0.0.1
INFO: Updating "~/.julia/environments/v0.6/Manifest.toml"
 [1c4bc1b3] + Actors v0.0.1
 [03a36d30] + EasyPkg v0.3.0

pkg> rm Actors
INFO: Updating "~/.julia/environments/v0.6/Project.toml"
 [1c4bc1b3] - Actors v0.0.1
INFO: Updating "~/.julia/environments/v0.6/Manifest.toml"
 [1c4bc1b3] - Actors v0.0.1
 [03a36d30] - EasyPkg v0.3.0

pkg> add Actors
There are multiple registered `Actors` packages, choose one:
   Registry: MyRegistry - Path: https://github.com/daqcore/Actors.jl.git
 > Registry: Uncurated - Path: https://github.com/daqcore/Actors.jl.git
INFO: Resolving package versions
INFO: Updating "~/.julia/environments/v0.6/Project.toml"
 [1c4bc1b3] + Actors v0.1.0
INFO: Updating "~/.julia/environments/v0.6/Manifest.toml"
 [1c4bc1b3] + Actors v0.1.0
 [34da2185] + Compat v0.37.0
```