### PR TITLE
 Build dependent packages and support varargs in API.build

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -242,6 +242,7 @@ function build(env::EnvCache, pkgs::Vector{PackageSpec})
     end
     manifest_resolve!(env, pkgs)
     ensure_resolved(env, pkgs)
+    Pkg3.Operations.resolve_versions!(env, pkgs, false)
     Pkg3.Operations.build_versions(env, [pkg.uuid for pkg in pkgs])
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -225,8 +225,8 @@ function gc(env::EnvCache=EnvCache(); period = Week(6), preview=env.preview[])
 end
 
 
-build(pkg::String) = build([pkg])
-build(pkgs::Vector{String}) = build([PackageSpec(pkg) for pkg in pkgs])
+build(pkgs...) = build([PackageSpec(pkg) for pkg in pkgs])
+build(pkg::Array{Union{}, 1}) = build(PackageSpec[])
 build(pkg::PackageSpec) = build([pkg])
 build(pkgs::Vector{PackageSpec}) = build(EnvCache(), pkgs)
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -233,7 +233,6 @@ function _get_deps!(env::EnvCache, deps_graph::DepsGraph, uuid::Base.Random.UUID
     end
 end
 
-
 build(pkgs...) = build([PackageSpec(pkg) for pkg in pkgs])
 build(pkg::Array{Union{}, 1}) = build(PackageSpec[])
 build(pkg::PackageSpec) = build([pkg])

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -147,20 +147,18 @@ function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
 end
 
 "Resolve a set of versions given package version specs"
-function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec}, fix_all = true)::Dict{UUID,VersionNumber}
+function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec})::Dict{UUID,VersionNumber}
     info("Resolving package versions")
+    # anything not mentioned is fixed
     uuids = UUID[pkg.uuid for pkg in pkgs]
     uuid_to_name = Dict{UUID,String}()
-    # anything not mentioned is fixed
-    if fix_all
-        for (name::String, uuid::UUID) in env.project["deps"]
-            uuid_to_name[uuid] = name
-            uuid in uuids && continue
-            info = manifest_info(env, uuid)
-            haskey(info, "version") || continue
-            ver = VersionNumber(info["version"])
-            push!(pkgs, PackageSpec(name, uuid, ver))
-        end
+    for (name::String, uuid::UUID) in env.project["deps"]
+        uuid_to_name[uuid] = name
+        uuid in uuids && continue
+        info = manifest_info(env, uuid)
+        haskey(info, "version") || continue
+        ver = VersionNumber(info["version"])
+        push!(pkgs, PackageSpec(name, uuid, ver))
     end
     # construct data structures for resolver and call it
     reqs = Requires(pkg.uuid => pkg.version for pkg in pkgs)

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -147,18 +147,20 @@ function deps_graph(env::EnvCache, pkgs::Vector{PackageSpec})
 end
 
 "Resolve a set of versions given package version specs"
-function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec})::Dict{UUID,VersionNumber}
+function resolve_versions!(env::EnvCache, pkgs::Vector{PackageSpec}, fix_all = true)::Dict{UUID,VersionNumber}
     info("Resolving package versions")
-    # anything not mentioned is fixed
     uuids = UUID[pkg.uuid for pkg in pkgs]
     uuid_to_name = Dict{UUID,String}()
-    for (name::String, uuid::UUID) in env.project["deps"]
-        uuid_to_name[uuid] = name
-        uuid in uuids && continue
-        info = manifest_info(env, uuid)
-        haskey(info, "version") || continue
-        ver = VersionNumber(info["version"])
-        push!(pkgs, PackageSpec(name, uuid, ver))
+    # anything not mentioned is fixed
+    if fix_all
+        for (name::String, uuid::UUID) in env.project["deps"]
+            uuid_to_name[uuid] = name
+            uuid in uuids && continue
+            info = manifest_info(env, uuid)
+            haskey(info, "version") || continue
+            ver = VersionNumber(info["version"])
+            push!(pkgs, PackageSpec(name, uuid, ver))
+        end
     end
     # construct data structures for resolver and call it
     reqs = Requires(pkg.uuid => pkg.version for pkg in pkgs)


### PR DESCRIPTION
Previously ```build``` command was not building dependent packages.
Added support for varargs in `Pkg3.API.build,` as present in `Pkg.build`
```
julia> Pkg3.build("PyCall", "DataFrames")
INFO: Resolving package versions
INFO: Building Conda [b26546424d5f3ac3]...
INFO:  → /home/osboxes/.julia/packages/N8e4/u0lj/deps/build.log
INFO: Building PyCall [2ba54612238a85ee]...
INFO:  → /home/osboxes/.julia/packages/mbAM/vGCc/deps/build.log
INFO: Building SpecialFunctions [a052147e601e7926]...
INFO:  → /home/osboxes/.julia/packages/FTLa/YKDc/deps/build.log

```