### PR TITLE
Add backtracking to max-sum, improve greedy solver; the solver is now exact

### DIFF
--- a/bin/Pkg2/types.jl
+++ b/bin/Pkg2/types.jl
@@ -5,7 +5,6 @@ module Types
 export VersionInterval, VersionSet
 import Base: show, isempty, in, intersect, union!, union, ==, hash, copy, deepcopy_internal
 
-import Pkg3.equalto
 import Pkg3.iswindows
 
 struct VersionInterval

--- a/src/resolve/MaxSum.jl
+++ b/src/resolve/MaxSum.jl
@@ -11,26 +11,21 @@ export UnsatError, Messages, maxsum
 # An exception type used internally to signal that an unsatisfiable
 # constraint was detected
 struct UnsatError <: Exception
-    trace
+    p0::Int
 end
 
 # Some parameters to drive the decimation process
 mutable struct MaxSumParams
-    nondec_iterations # number of initial iterations before starting
-                      # decimation
     dec_interval # number of iterations between decimations
     dec_fraction # fraction of nodes to decimate at every decimation
                  # step
 
     function MaxSumParams()
         accuracy = parse(Int, get(ENV, "JULIA_PKGRESOLVE_ACCURACY", "1"))
-        if accuracy <= 0
-            error("JULIA_PKGRESOLVE_ACCURACY must be > 0")
-        end
-        nondec_iterations = accuracy * 20
-        dec_interval = accuracy * 10
+        accuracy > 0 || error("JULIA_PKGRESOLVE_ACCURACY must be > 0")
+        dec_interval = accuracy * 5
         dec_fraction = 0.05 / accuracy
-        return new(nondec_iterations, dec_interval, dec_fraction)
+        return new(dec_interval, dec_fraction)
     end
 end
 
@@ -52,82 +47,117 @@ mutable struct Messages
     # backup of the initial value of fld, to be used when resetting
     initial_fld::Vector{Field}
 
-    # the solution is built progressively by a decimation process
-    solution::Vector{Int}
-    num_nondecimated::Int
-
-    # try to build a trace
-    trace::Vector{Any}
-
     function Messages(graph::Graph)
         np = graph.np
         spp = graph.spp
+        gadj = graph.gadj
         gconstr = graph.gconstr
         req_inds = graph.req_inds
+        ignored = graph.ignored
         pvers = graph.data.pvers
         pdict = graph.data.pdict
 
         ## generate wveights (v0 == spp[p0] is the "uninstalled" state)
         vweight = [[VersionWeight(v0 < spp[p0] ? pvers[p0][v0] : v"0") for v0 = 1:spp[p0]] for p0 = 1:np]
 
-        # external fields: favor newest versions over older, and no-version over all
-        fld = [[FieldValue(0, zero(VersionWeight), vweight[p0][v0], (v0==spp[p0]), 0) for v0 = 1:spp[p0]] for p0 = 1:np]
-
-        # enforce constraints
-        for p0 = 1:np
-            fld0 = fld[p0]
-            gconstr0 = gconstr[p0]
-            for v0 = 1:spp[p0]
-                gconstr0[v0] || (fld0[v0] = FieldValue(-1))
-            end
-        end
-
-        # favor explicit requirements
-        for rp0 in req_inds
-            fld0 = fld[rp0]
-            gconstr0 = gconstr[rp0]
-            for v0 = 1:spp[rp0]-1
-                gconstr0[v0] || continue
-                # the state is one of those explicitly requested:
-                # favor it at a higer level than normal (upgrade
-                # FieldValue from l2 to l1)
-                fld0[v0] += FieldValue(0, vweight[rp0][v0], -vweight[rp0][v0])
-            end
-        end
-
-        # normalize fields
-        for p0 = 1:np
-            fld[p0] .-= maximum(fld[p0])
-        end
+        # external fields: favor newest versions over older, and no-version over all;
+        #                  explicit requirements use level l1 instead of l2
+        fv(p0, v0) = p0 ∈ req_inds ?
+            FieldValue(0, vweight[p0][v0],     zero(VersionWeight), (v0==spp[p0])) :
+            FieldValue(0, zero(VersionWeight), vweight[p0][v0],     (v0==spp[p0]))
+        fld = [[fv(p0, v0) for v0 = 1:spp[p0]] for p0 = 1:np]
 
         initial_fld = [copy(f0) for f0 in fld]
 
-        # initialize cavity messages to 0
-        gadj = graph.gadj
-        msg = [[zeros(FieldValue, spp[p0]) for j1 = 1:length(gadj[p0])] for p0 = 1:np]
+        # allocate cavity messages
+        msg = [[Field(spp[p0]) for j1 = 1:length(gadj[p0])] for p0 = 1:np]
 
+        msgs = new(msg, fld, initial_fld)
+
+        reset_messages!(msgs, graph)
+
+        return msgs
+    end
+end
+
+# enforce constraints and normalize fields;
+# zero out all cavity messages
+function reset_messages!(msgs::Messages, graph::Graph)
+    msg = msgs.msg
+    fld = msgs.fld
+    initial_fld = msgs.initial_fld
+    np = graph.np
+    spp = graph.spp
+    gconstr = graph.gconstr
+    ignored = graph.ignored
+    for p0 = 1:np
+        ignored[p0] && continue
+        map(m->fill!(m, zero(FieldValue)), msg[p0])
+        copy!(fld[p0], initial_fld[p0])
+        gconstr0 = gconstr[p0]
+        for v0 = 1:spp[p0]
+            gconstr0[v0] || (fld[p0][v0] = FieldValue(-1))
+        end
+        fld[p0] .-= maximum(fld[p0])
+    end
+    return msgs
+end
+
+mutable struct SolutionTrace
+    # the solution is built progressively by a decimation process
+    solution::Vector{Int}
+    num_nondecimated::Int
+
+    best::Vector{Int}
+    staged::Union{Tuple{Int,Int},Void}
+
+    function SolutionTrace(graph::Graph)
+        np = graph.np
         solution = zeros(Int, np)
         num_nondecimated = np
 
-        trace = []
+        best = zeros(Int, np)
+        staged = nothing
 
-        return new(msg, fld, initial_fld, solution, num_nondecimated, trace)
+        return new(solution, num_nondecimated, best, staged)
+    end
+end
+
+function update_solution!(strace::SolutionTrace, graph::Graph)
+    np = graph.np
+    ignored = graph.ignored
+    gconstr = graph.gconstr
+    solution = strace.solution
+    best = strace.best
+    nnd = np
+    fill!(solution, 0)
+    for p0 in find(ignored)
+        s0 = findfirst(gconstr[p0])
+        solution[p0] = s0
+        nnd -= 1
+    end
+    strace.num_nondecimated = nnd
+    if nnd ≤ sum(best .== 0)
+        copy!(best, solution)
+        strace.staged = nothing
+        return true
+    else
+        return false
     end
 end
 
 # This is the core of the max-sum solver:
 # for a given node p0 (i.e. a package) updates all
 # input cavity messages and fields of its neighbors
-function update(p0::Int, graph::Graph, msgs::Messages)
+function update!(p0::Int, graph::Graph, msgs::Messages)
     gadj = graph.gadj
     gmsk = graph.gmsk
-    gdir = graph.gdir
     adjdict = graph.adjdict
+    ignored = graph.ignored
     spp = graph.spp
     np = graph.np
     msg = msgs.msg
     fld = msgs.fld
-    solution = msgs.solution
 
     maxdiff = zero(FieldValue)
 
@@ -141,23 +171,15 @@ function update(p0::Int, graph::Graph, msgs::Messages)
     for j0 in 1:length(gadj0)
 
         p1 = gadj0[j0]
-        solution[p1] > 0 && continue # already decimated
+        ignored[p1] && continue
         j1 = adjdict0[p1]
         #@assert j0 == adjdict[p1][p0]
         bm1 = gmsk[p1][j1]
-        dir1 = gdir[p1][j1]
         spp1 = spp[p1]
         msg1 = msg[p1]
 
-        # compute the output cavity message p0->p1
-        cavmsg = fld0 - msg0[j0]
-
-        if dir1 == GraphType.BACKWARDS
-            # p0 depends on p1
-            for v0 = 1:spp0-1
-                cavmsg[v0] += FieldValue(0, VersionWeight(0), VersionWeight(0), 0, v0)
-            end
-        end
+        # compute the output cavity field p0->p1
+        cavfld = fld0 - msg0[j0]
 
         # keep the old input cavity message p0->p1
         oldmsg = msg1[j1]
@@ -165,43 +187,27 @@ function update(p0::Int, graph::Graph, msgs::Messages)
         # init the new message to minus infinity
         newmsg = [FieldValue(-1) for v1 = 1:spp1]
 
-        # compute the new message by passing cavmsg
+        # compute the new message by passing cavfld
         # through the constraint encoded in the bitmask
-        # (nearly equivalent to:
-        #    newmsg = [maximum(cavmsg[bm1[:,v1]]) for v1 = 1:spp1]
-        #  except for the directional term)
-        m = FieldValue(-1)
-        for v1 = 1:spp1
-            for v0 = 1:spp0
-                if bm1[v0, v1]
-                    newmsg[v1] = max(newmsg[v1], cavmsg[v0])
-                end
-            end
-            if dir1 == GraphType.FORWARD && v1 != spp1
-                # p1 depends on p0
-                newmsg[v1] += FieldValue(0, VersionWeight(0), VersionWeight(0), 0, v1)
-            end
-            m = max(m, newmsg[v1])
+        # (equivalent to:
+        #    newmsg = [maximum(cavfld[bm1[:,v1]]) for v1 = 1:spp1]
+        # )
+        for v1 = 1:spp1, v0 = 1:spp0
+            bm1[v0, v1] || continue
+            newmsg[v1] = max(newmsg[v1], cavfld[v0])
         end
-        if !validmax(m)
-            # No state available without violating some
-            # hard constraint
-            throw(UnsatError(msgs.trace))
-        end
+        m = maximum(newmsg)
+        validmax(m) || throw(UnsatError(p0)) # No state available without violating some
+                                             # hard constraint
 
         # normalize the new message
-        for v1 = 1:spp1
-            newmsg[v1] -= m
-        end
+        newmsg .-= m
 
         diff = newmsg - oldmsg
         maxdiff = max(maxdiff, maximum(abs.(diff)))
 
         # update the field of p1
-        fld1 = fld[p1]
-        for v1 = 1:spp1
-            fld1[v1] += diff[v1]
-        end
+        fld[p1] .+= diff
 
         # put the newly computed message in place
         msg1[j1] = newmsg
@@ -209,7 +215,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
     return maxdiff
 end
 
-# A simple shuffling machinery for the update order in iterate()
+# A simple shuffling machinery for the update order in iterate!()
 # (wouldn't pass any random quality test but it's arguably enough)
 mutable struct NodePerm
     p::Vector{Int}
@@ -233,161 +239,242 @@ Base.done(perm::NodePerm, x) = done(perm.p, x)
 
 # Call update for all nodes (i.e. packages) in
 # random order
-function iterate(graph::Graph, msgs::Messages, perm::NodePerm)
+function iterate!(graph::Graph, msgs::Messages, perm::NodePerm)
     maxdiff = zero(FieldValue)
     shuffle!(perm)
     for p0 in perm
-        maxdiff0 = update(p0, graph, msgs)
+        graph.ignored[p0] && continue
+        maxdiff0 = update!(p0, graph, msgs)
         maxdiff = max(maxdiff, maxdiff0)
     end
     return maxdiff
 end
 
-function decimate1(p0::Int, graph::Graph, msgs::Messages)
-    solution = msgs.solution
+function decimate1!(p0::Int, graph::Graph, strace::SolutionTrace, msgs::Messages)
+    solution = strace.solution
     fld = msgs.fld
     adjdict = graph.adjdict
     gmsk = graph.gmsk
     gconstr = graph.gconstr
 
     @assert solution[p0] == 0
+    @assert !graph.ignored[p0]
     fld0 = fld[p0]
     s0 = indmax(fld0)
     # only do the decimation if it is consistent with
     # the constraints...
-    gconstr[p0][s0] || return false
+    gconstr[p0][s0] || return 0
     # ...and with the previously decimated nodes
     for p1 in find(solution .> 0)
         haskey(adjdict[p0], p1) || continue
-        s1 = indmax(fld[p1])
+        s1 = solution[p1]
         j1 = adjdict[p0][p1]
-        gmsk[p1][j1][s0,s1] || return false
+        gmsk[p1][j1][s0,s1] || return 0
     end
-    #println("DECIMATING $p0 (s0=$s0 fld=$fld0)")
-    for v0 = 1:length(fld0)
-        v0 == s0 && continue
-        fld0[v0] = FieldValue(-1)
-    end
-    msgs.solution[p0] = s0
-    msgs.num_nondecimated -= 1
-    push!(msgs.trace, (p0,s0))
-    return true
+    solution[p0] = s0
+    strace.num_nondecimated -= 1
+    return s0
 end
 
-function reset_messages!(msgs::Messages)
-    msg = msgs.msg
+function decimate!(graph::Graph, strace::SolutionTrace, msgs::Messages, n::Integer)
+    np = graph.np
+    gconstr = graph.gconstr
+    ignored = graph.ignored
     fld = msgs.fld
-    initial_fld = msgs.initial_fld
-    solution = msgs.solution
-    np = length(fld)
+
+    @assert n ≥ 1
+    dtrace = Tuple{Int,Int}[]
+    dec = 0
+
+    fldorder = sort(find(.!(ignored)), by=p0->secondmax(fld[p0], gconstr[p0]))
+    for p0 in fldorder
+        s0 = decimate1!(p0, graph, strace, msgs)
+        s0 == 0 && continue
+        push!(dtrace, (p0,s0))
+        dec += 1
+        dec == n && break
+    end
+
+    return dtrace
+end
+
+function clean_forbidden!(graph::Graph, msgs::Messages)
+    np = graph.np
+    gconstr = graph.gconstr
+    ignored = graph.ignored
+    fld = msgs.fld
+    affected = Tuple{Int,Int}[]
+    removed = 0
+
     for p0 = 1:np
-        map(m->fill!(m, zero(FieldValue)), msg[p0])
-        solution[p0] > 0 && continue
-        fld[p0] = copy(initial_fld[p0])
-    end
-    return msgs
-end
-
-# If normal convergence fails (or is too slow) fix the most
-# polarized packages by adding extra infinite fields on every state
-# but the maximum
-function decimate(n::Int, graph::Graph, msgs::Messages)
-    #println("DECIMATING $n NODES")
-    adjdict = graph.adjdict
-    fld = msgs.fld
-    solution = msgs.solution
-    fldorder = sortperm(fld, by=secondmax)
-    did_dec = false
-    for p0 in fldorder
-        solution[p0] > 0 && continue
-        did_dec |= decimate1(p0, graph, msgs)
-        n -= 1
-        n == 0 && break
-    end
-    @assert n == 0
-
-    did_dec && @goto ok
-
-    # did not succeed in decimating anything;
-    # try to decimate at least one node
-    for p0 in fldorder
-        solution[p0] > 0 && continue
-        decimate1(p0, graph, msgs) && @goto ok
-    end
-
-    # still didn't succeed, give up
-    p0 = findfirst(solution .== 0)
-    throw(UnsatError(msgs.trace))
-
-    @label ok
-
-    reset_messages!(msgs)
-    return
-end
-
-# In case ties still exist at convergence, break them and
-# keep converging
-function break_ties(msgs::Messages)
-    fld = msgs.fld
-    unbroken_ties = Int[]
-    for p0 = 1:length(fld)
+        ignored[p0] && continue
         fld0 = fld[p0]
-        z = 0
-        m = typemin(FieldValue)
-        for v0 = 1:length(fld0)
-            if fld0[v0] > m
-                m = fld0[v0]
-                z = 1
-            elseif fld0[v0] == m
-                z += 1
-            end
-        end
-        if z > 1
-            #println("TIE! p0=$p0")
-            decimate1(p0, msgs) && return false
-            push!(unbroken_ties, p0)
+        gconstr0 = gconstr[p0]
+        for v0 in find(gconstr0)
+            validmax(fld0[v0]) && continue
+            push!(affected, (p0,v0))
+            removed += 1
         end
     end
-    # If there were ties, but none were broken, bail out
-    isempty(unbroken_ties) || throw(PkgError(first(unbroken_ties)))
-    return true
+    return affected
 end
 
-# Iterative solver: run iterate() until convergence
+# Iterative solver: run iterate!() until convergence
 # (occasionally calling decimate())
-function maxsum(graph::Graph, msgs::Messages)
+function maxsum(graph::Graph)
     params = MaxSumParams()
 
-    it = 0
     perm = NodePerm(graph.np)
+    strace = SolutionTrace(graph)
+    msgs = Messages(graph)
+
+    push_snapshot!(graph)
+    # gconstr_sav = graph.gconstr
+    # ignored_sav = graph.ignored
+    ok = converge!(graph, msgs, strace, perm, params)
+    # @assert graph.gconstr ≡ gconstr_sav
+    # @assert graph.ignored ≡ ignored_sav
+    pop_snapshot!(graph)
+    if ok
+        @assert strace.best == strace.solution
+        @assert strace.num_nondecimated == 0
+        @assert all(strace.solution .> 0)
+        @assert strace.staged ≡ nothing
+    else
+        @assert strace.staged ≢ nothing
+    end
+    return ok, strace.best, strace.staged
+end
+
+function try_simplify_graph_soft!(graph, sources)
+    try
+        simplify_graph_soft!(graph, sources, log_events = false)
+    catch err
+        err isa PkgError || rethrow(err)
+        return false
+    end
+    return true
+end
+
+function converge!(graph::Graph, msgs::Messages, strace::SolutionTrace, perm::NodePerm, params::MaxSumParams)
+    is_best_sofar = update_solution!(strace, graph)
+
+    # this is the base of the recursion: the case when
+    # the solver has succeeded in decimating everything
+    strace.num_nondecimated == 0 && return true
+
+    reset_messages!(msgs, graph)
+
+    # perform some maxsum iterations, then decimate one node.
+    # If failure happens during this process, we bail (return false)
+    it = 0
+    for it = 1:params.dec_interval
+        local maxdiff::FieldValue
+        try
+            maxdiff = iterate!(graph, msgs, perm)
+        catch err
+            err isa UnsatError || rethrow(err)
+            if is_best_sofar
+                p0 = err.p0
+                s0 = findlast(graph.gconstr[p0])
+                strace.staged = (p0, s0)
+            end
+            return false
+        end
+        maxdiff == zero(FieldValue) && break
+    end
+
+    # if maxsum has found some forbidden states, remove
+    # them and propagate the effect
+    affected = clean_forbidden!(graph, msgs)
+
+    isempty(affected) && @goto decimate
+
+    sources = Set{Int}()
+    for (p0,v0) in affected
+        graph.gconstr[p0][v0] = false
+        push!(sources, p0)
+    end
+
+    if !try_simplify_graph_soft!(graph, sources)
+        # found an implicit contradiction
+        is_best_sofar && (strace.staged = first(affected))
+        return false
+    end
+    return converge!(graph, msgs, strace, perm, params)
+
+    @label decimate
+
+    ndec = max(1, round(Int, params.dec_fraction * strace.num_nondecimated))
+    dtrace = decimate!(graph, strace, msgs, ndec)
+    if isempty(dtrace)
+        # decimation has failed, all candidate states are forbidden
+        # (which shouldn't really happen, this is a failsafe)
+        if is_best_sofar
+            # pick the first decimation candidate
+            smx(p1) = secondmax(msgs.fld[p1], graph.gconstr[p1])
+            p0 = reduce((p1,p2)->(smx(p1)≤smx(p2) ? p1 : p2), find(.!(graph.ignored)))
+            s0 = indmax(fld[p0])
+            strace.staged = dec_firstcandidate(graph, msgs)
+        end
+        return false
+    end
+
     while true
-        it += 1
-        maxdiff = iterate(graph, msgs, perm)
-        #println("it = $it maxdiff = $maxdiff")
+        # decimation has succeeded, at least nominally.
+        # We need to propagate its effects and check for contradictions
 
-        if maxdiff == zero(FieldValue)
-            break_ties(msgs) && break
-            continue
+        lentr = length(dtrace)
+        if lentr == 1 && is_best_sofar
+            strace.staged = dtrace[1]
         end
-        if it >= params.nondec_iterations &&
-           (it - params.nondec_iterations) % params.dec_interval == 0
-            numdec = clamp(floor(Int, params.dec_fraction * graph.np), 1, msgs.num_nondecimated)
-            decimate(numdec, graph, msgs)
-            msgs.num_nondecimated == 0 && break
+
+        push_snapshot!(graph)
+        # info("setting dtrace=$dtrace")
+        for (p0,s0) in dtrace
+            @assert !graph.ignored[p0]
+            @assert graph.gconstr[p0][s0]
+            fill!(graph.gconstr[p0], false)
+            graph.gconstr[p0][s0] = true
+            graph.ignored[p0] = true
         end
+
+        # if decimation has produced an implicit contradiction, backtrack
+        try_simplify_graph_soft!(graph, Set{Int}(first.(dtrace))) || @goto backtrack
+
+        # otherwise, keep going...
+        converge!(graph, msgs, strace, perm, params) && (pop_snapshot!(graph); return true)
+
+        @label backtrack
+
+        # warn("reverting dtrace=$dtrace")
+
+        # if we're here, the last decimation step has been proven to lead
+        # to an unsat situation at some point, we need to roll it back
+
+        # revert the state of the constraints
+        pop_snapshot!(graph)
+
+        lentr == 1 && break
+        # halve the dtrace
+        deleteat!(dtrace, ((lentr÷2)+1):lentr)
     end
 
-    # Finally, decimate everything just to
-    # check against inconsistencies
-    # (old_numnondec is saved just to prevent
-    # wrong messages about accuracy)
-    old_numnondec = msgs.num_nondecimated
-    while msgs.num_nondecimated > 0
-        decimate(msgs.num_nondecimated, graph, msgs)
-    end
-    msgs.num_nondecimated = old_numnondec
+    @assert length(dtrace) == 1
+    p0, s0 = dtrace[1]
 
-    return copy(msgs.solution)
+    is_best_sofar && @assert strace.staged ≢ nothing
+
+    # forbid the state used in the last attempt
+    # (note that we're working on the "entry" snapshot here!)
+    graph.gconstr[p0][s0] = false
+    # check if we have finished all available possibilities
+    any(graph.gconstr[p0]) || return false
+    # if neither the s0 state nor its negation are valid, give up
+    try_simplify_graph_soft!(graph, Set{Int}([p0])) || return false
+
+    # keep going, with one possible state less...
+    return converge!(graph, msgs, strace, perm, params)
 end
 
 end

--- a/test/NastyGenerator.jl
+++ b/test/NastyGenerator.jl
@@ -1,0 +1,96 @@
+module NastyGenerator
+
+pn(i) = "P$i"
+randvers(k::Int) = VersionNumber(rand(0:k), rand(0:k), rand(0:k))
+
+function randvspec(k::Int)
+    lb, ub = randvers(k), randvers(k)
+    if lb > ub
+        lb, ub = ub, lb
+    end
+
+    slb = rand() < 0.1 ? "0" : string(lb)
+    sub = rand() < 0.1 ? "*" : string(ub)
+
+    return "$slb-$sub"
+end
+
+"""
+Generates a random graph with 2 planted solutions (or quasi-solutions if sat==false).
+With the right parameters, this is quite hard to solve for large sizes.
+For added fun, the two planted solutions are cycles.
+We want the solver to find the best of the two, of course.
+This is an extremely unrealistic scenario and it's only intended to stress-test the solver.
+Note that the "problematic" output assumes that all non-planted versions will be
+uninstallable, which is only the case for some regimes of the parameters (e.g. large
+enough d).
+"""
+function generate_nasty(n::Int,             # size of planted solutions
+                        m::Int;             # size of the graph
+                        k::Int = 10,        # version number limit
+                        q::Int = 10,        # versions per package (upper bound)
+                        d::Int = 10,        # neighbors per package
+                        seed::Integer = 32524,
+                        sat::Bool = true    # create a satisfiable problem?
+                       )
+    @assert m ≥ n
+    d ≤ m-1 || warn("d=$d, should be ≤ m-1=$(m-1)")
+
+    srand(seed)
+
+    allvers = [sort(unique(randvers(k) for j = 1:q)) for i = 1:m]
+
+    planted1 = [rand(2:length(allvers[i])) for i = 1:n]
+
+    planted2 = [rand(1:(planted1[i]-1)) for i = 1:n]
+
+    deps = []
+    problematic = []
+
+    # random dependencies
+    for i = 1:m, j = 1:length(allvers[i])
+        if i ≤ n && (planted1[i] == j || planted2[i] == j)
+            if j == planted1[i]
+                if i < n
+                    push!(deps, [pn(i), allvers[i][j], pn(i+1), "$(allvers[i+1][planted1[i+1]])-*"])
+                else
+                    if !sat
+                        push!(deps, [pn(i), allvers[i][j], pn(1), "0-$(allvers[1][planted2[1]])"])
+                    else
+                        push!(deps, [pn(i), allvers[i][j], pn(1), "0-*"])
+                    end
+                end
+            else # j == planted2[i]
+                if i < n
+                    push!(deps, [pn(i), allvers[i][j], pn(i+1), "0-$(allvers[i+1][planted2[i+1]])"])
+                else
+                    if !sat
+                        push!(deps, [pn(i), allvers[i][j], pn(1), "$(allvers[1][planted1[1]])-*"])
+                    else
+                        push!(deps, [pn(i), allvers[i][j], pn(1), "0-*"])
+                    end
+                end
+            end
+            sat || push!(problematic, [pn(i), allvers[i][j]])
+            continue
+        end
+
+        s = shuffle([1:(i-1); (i+1):m])[1:min(d,m-1)]
+        for a in s
+            push!(deps, [pn(i), allvers[i][j], pn(a), randvspec(k)])
+        end
+        push!(problematic, [pn(i), allvers[i][j]])
+    end
+
+    reqs = [[pn(1), "*"]]
+    # reqs = [[pn(1), string(allvers[1][planted1[1]])]]
+
+    # info("SOLUTION: $([(i,planted1[i]) for i = 1:n])")
+    # info("REST: $([(i,length(allvers[i])+1) for i = (n+1):m])")
+
+    want = Dict(pn(i) => allvers[i][planted1[i]] for i = 1:n)
+
+    return deps, reqs, want, problematic
+end
+
+end # module


### PR DESCRIPTION
With this change, the solver is now exact, at least for what concerns SAT/UNSAT discrimination, i.e. it should always find a solution if it exists, and fail only when it doesn't, producing a reasonable log trace in that case. (Ok to be perfectly honest the exactness claim relies on a conjecture that I haven't proven yet. But I think it should hold. It certainly does in all the cases that I tested.)

Optimality - finding the best solution among those that exist - is still based on a heuristic, unless the solution is found by the greedy solver, which is quite improved as well anyway - so much so that I had to explicitly add a new generator of nasty test instances just to trick it.

Of course, the problem being NP-hard in general, this means that in principle the solver could now take ages to decide whether a problem is satisfiable. From my (many) experiments, I don't think this will be a problem at all in practice. However, we could add a timer, for example, in case it turns out that I'm being too optimistic.

@StefanKarpinski: With this, I think that something like #52 could be addressed by simply trying first with the full constraints, then if the problem is unsat some second-level constraints could be relaxed, etc.

Also, this is based on top of #86, which is on top of #83, which is on top of #81. Things are starting to pile up... I really need some kind of feedback on #81.


  