### PR TITLE
parameterize IO in TOML parser

### DIFF
--- a/ext/TOML/src/parser.jl
+++ b/ext/TOML/src/parser.jl
@@ -34,18 +34,18 @@ Base.getindex(tbl::Table, key::AbstractString) = tbl.values[key]
 Base.haskey(tbl::Table, key::AbstractString) = haskey(tbl.values ,key)
 
 "Parser error exception"
-mutable struct ParserError <: Exception
+struct ParserError <: Exception
     lo::Int
     hi::Int
     msg::String
 end
 
 "TOML Parser"
-mutable struct Parser
-    input::IO
+struct Parser{IO_T <: IO}
+    input::IO_T
     errors::Vector{ParserError}
 
-    Parser(input::IO) = new(input, ParserError[])
+    Parser(input::IO_T) where {IO_T <: IO}  = new{IO_T}(input, ParserError[])
 end
 Parser(input::String) = Parser(IOBuffer(input))
 Base.error(p::Parser, l, h, msg) = push!(p.errors, ParserError(l, h, msg))


### PR DESCRIPTION
Make the `deps_graph!` loop that collects dependencies take 0.9 seconds instead of 1.6 seconds when doing `add DifferentialEquations`. Shaving off 0.7 seconds is pretty good compared to the total runtime ~3s.