### PR TITLE
Significantly improve performance by not using broadcasting for very small arrays

### DIFF
--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -245,7 +245,7 @@ mutable struct Graph
         data = GraphData(versions, deps, compat, uuid_to_name, verbose = verbose)
         pkgs, np, spp, pdict, pvers, vdict, rlog = data.pkgs, data.np, data.spp, data.pdict, data.pvers, data.vdict, data.rlog
 
-        extended_deps = [[Dict{Int,BitVector}() for v0 = 1:(spp[p0]-1)] for p0 = 1:np]
+        extended_deps = [Vector{Dict{Int,BitVector}}(spp[p0]-1) for p0 = 1:np]
         for p0 = 1:np, v0 = 1:(spp[p0]-1)
             n2u = Dict{String,UUID}()
             vn = pvers[p0][v0]
@@ -275,7 +275,11 @@ mutable struct Graph
                 get!(req, pdict[uuid]) do; VersionSpec() end
             end
             # Translate the requirements into bit masks
-            req_msk = Dict(p1 => (pvers[p1][1:(spp[p1]-1)] .∈ vs) for (p1,vs) in req)
+            req_msk = Dict{Int,BitVector}()
+            for (p1, vs) in req
+                pv = pvers[p1]
+                req_msk[p1] = [pv[i] ∈ vs for i in 1:(spp[p1]-1)]
+            end
             extended_deps[p0][v0] = req_msk
         end
 

--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -148,12 +148,12 @@ mutable struct GraphData
         # equivalence classes (at the beginning each state represents just itself)
         eq_vn(v0, p0) = (v0 == spp[p0] ? nothing : pvers[p0][v0])
 
-        # Hot code
+        # Hot code, measure performance before changing
         eq_classes = Dict{UUID,Dict{InstState,Set{InstState}}}()
         for p0 = 1:np
             d = Dict{InstState, Set{InstState}}()
             for v0 = 1:spp[p0]
-                let p0 = p0
+                let p0 = p0 # Due to https://github.com/JuliaLang/julia/issues/15276
                     d[eq_vn(v0,p0)] = Set([eq_vn(v0,p0)])
                 end
             end
@@ -161,7 +161,7 @@ mutable struct GraphData
         end
 
         # the resolution log is actually initialized below
-        rlog = ResolveLog(uuid_to_name, false)
+        rlog = ResolveLog(uuid_to_name, verbose)
 
         data = new(pkgs, np, spp, pdict, pvers, vdict, uuid_to_name, pruned, eq_classes, rlog)
 
@@ -253,12 +253,14 @@ mutable struct Graph
         extra_uuids = union(keys(reqs), keys(fixed), map(fx->keys(fx.requires), values(fixed))...)
         extra_uuids ⊆ keys(versions) || error("unknown UUID found in reqs/fixed") # TODO?
 
+        # Type assert below due to https://github.com/JuliaLang/julia/issues/25918
         data = GraphData(versions, deps, compat, uuid_to_name, verbose = verbose)::GraphData
         pkgs, np, spp, pdict, pvers, vdict, rlog = data.pkgs, data.np, data.spp, data.pdict, data.pvers, data.vdict, data.rlog
 
         local extended_deps
-        let spp = spp
-            extended_deps = [Vector{Dict{Int,BitVector}}(spp[p0]-1) for p0 = 1:np]::Vector{Vector{Dict{Int, BitVector}}}
+        let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
+            # Type assert below to help inference
+            extended_deps = [Vector{Dict{Int,BitVector}}(spp[p0]-1) for p0 = 1:np]::Vector{Vector{Dict{Int,BitVector}}}
         end
         for p0 = 1:np, v0 = 1:(spp[p0]-1)
             n2u = Dict{String,UUID}()
@@ -289,7 +291,7 @@ mutable struct Graph
                 get!(req, pdict[uuid]) do; VersionSpec() end
             end
             # Translate the requirements into bit masks
-            # Hot code
+            # Hot code, measure performance before changing
             req_msk = Dict{Int,BitVector}()
             @inbounds for (p1, vs) in req
                 pv = pvers[p1]
@@ -305,7 +307,7 @@ mutable struct Graph
         gadj = [Int[] for p0 = 1:np]
         gmsk = [BitMatrix[] for p0 = 1:np]
         local gconstr
-        let spp = spp
+        let spp = spp # Due to https://github.com/JuliaLang/julia/issues/15276
             gconstr = [trues(spp[p0]) for p0 = 1:np]
         end
         adjdict = [Dict{Int,Int}() for p0 = 1:np]

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -270,7 +270,7 @@ const _empty_symbol = @static iswindows() ? "empty" : "∅"
 
 Base.isempty(s::VersionSpec) = all(isempty, s.ranges)
 @assert isempty(empty_versionspec)
-# Hot code
+# Hot code, measure performance before changing
 function Base.intersect(A::VersionSpec, B::VersionSpec)
     (isempty(A) || isempty(B)) && return copy(empty_versionspec)
     ranges = Vector{VersionRange}(length(A.ranges) * length(B.ranges))

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -251,7 +251,13 @@ struct VersionSpec
 end
 VersionSpec() = VersionSpec(VersionRange())
 
-Base.in(v::VersionNumber, s::VersionSpec) = any(v in r for r in s.ranges)
+# Hot code
+function Base.in(v::VersionNumber, s::VersionSpec)
+    for r in s.ranges
+        v in r && return true
+    end
+    return false
+end
 
 Base.convert(::Type{VersionSpec}, v::VersionNumber) = VersionSpec(VersionRange(v))
 Base.convert(::Type{VersionSpec}, r::VersionRange) = VersionSpec(VersionRange[r])
@@ -264,9 +270,15 @@ const _empty_symbol = @static iswindows() ? "empty" : "∅"
 
 Base.isempty(s::VersionSpec) = all(isempty, s.ranges)
 @assert isempty(empty_versionspec)
+# Hot code
 function Base.intersect(A::VersionSpec, B::VersionSpec)
     (isempty(A) || isempty(B)) && return copy(empty_versionspec)
-    ranges = [intersect(a,b) for a in A.ranges for b in B.ranges]
+    ranges = Vector{VersionRange}(length(A.ranges) * length(B.ranges))
+    i = 1
+    @inbounds for a in A.ranges, b in B.ranges
+        ranges[i] = intersect(a, b)
+        i += 1
+    end
     VersionSpec(ranges)
 end
 


### PR DESCRIPTION
From profiling, a large bottleneck was found in creating the `Graph`. This is because broadcasting (while convenient) actually has a significant overhead when used on small arrays. This was frequently the case here.

Before the changes here, creating the `Graph` took 0.93 seconds when adding DifferentialEquations with a total time for `Pkg3.add` of 2.0 seconds.

After the changes, `Graph`takes 0.30 seconds and total time 1.36 seconds.

The changes to Operations.jl are for readability, was hard to me to keep the nested generators in my head (also this way we only do one loop).