### PR TITLE
thread a "PkgContext" through most of the Operations.

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -18,7 +18,8 @@ const colors = Dict(
 )
 const color_dark = :light_black
 
-function status(env::EnvCache, mode::Symbol, use_as_api=false)
+function status(ctx::Context, mode::Symbol, use_as_api=false)
+    env = ctx.env
     project₀ = project₁ = env.project
     manifest₀ = manifest₁ = env.manifest
     diff = nothing
@@ -50,7 +51,7 @@ function status(env::EnvCache, mode::Symbol, use_as_api=false)
         if !isempty(c_diff)
             @info "Status $(pathrepr(env, env.manifest_file))"
             use_as_api || print_diff(c_diff)
-            diff =  Base.vcat(c_diff, diff)
+            diff = Base.vcat(c_diff, diff)
         end
     end
     return diff

--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -638,7 +638,7 @@ end
 
 function log_event_global!(graph::Graph, msg::String)
     rlog = graph.data.rlog
-    rlog.verbose && info(msg)
+    rlog.verbose && @info(msg)
     push!(rlog.globals, (nothing, msg))
 end
 

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -5,18 +5,8 @@ import Random
 import REPL
 using REPL.TerminalMenus
 
-@enum LoadErrorChoice LOAD_ERROR_QUERY LOAD_ERROR_INSTALL LOAD_ERROR_ERROR
-
-Base.@kwdef mutable struct GlobalSettings
-    load_error_choice::LoadErrorChoice = LOAD_ERROR_QUERY # query, install, or error, when not finding package on import
-    use_libgit2_for_all_downloads::Bool = false
-    num_concurrent_downloads::Int = 8
-    depots::Vector{String} = [joinpath(homedir(), ".julia")]
-end
-
-const GLOBAL_SETTINGS = GlobalSettings()
-
-depots() = GLOBAL_SETTINGS.depots
+const _depots = [joinpath(homedir(), ".julia")]
+depots() = _depots
 logdir() = joinpath(depots()[1], "logs")
 
 # load snapshotted dependencies
@@ -45,31 +35,31 @@ function __init__()
     end
 end
 
-function _query_if_interactive(base, name)
-    env = Types.EnvCache()
+# TODO: Hook this up to the code loading and make it execute
+# when in interactive mode and a package is not found
+function query_if_interactive(base, name)
+    ctx = Types.Context()
     pkgspec = [Types.PackageSpec(base)]
 
-    r = Operations.registry_resolve!(env, pkgspec)
+    r = Operations.registry_resolve!(ctx.env, pkgspec)
     Types.has_uuid(r[1]) || return nothing
 
-    GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_INSTALL && @goto install
-    GLOBAL_SETTINGS.load_error_choice == LOAD_ERROR_ERROR   && return nothing
+    ctx.load_error_choice == LOAD_ERROR_INSTALL && @goto install
+    ctx.load_error_choice == LOAD_ERROR_ERROR   && return nothing
 
     choice = TerminalMenus.request("Could not find package \e[1m$(base)\e[22m, do you want to install it?",
                    TerminalMenus.RadioMenu(["yes", "yes (remember)", "no", "no (remember)"]))
 
     if choice == 3 || choice == 4
-        choice == 4 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_ERROR)
+        choice == 4 && (ctx.load_error_choice = LOAD_ERROR_ERROR)
         return nothing
     end
 
-    choice == 2 && (GLOBAL_SETTINGS.load_error_choice = LOAD_ERROR_INSTALL)
+    choice == 2 && (ctx.load_error_choice = LOAD_ERROR_INSTALL)
     @label install
-    Pkg3.Operations.ensure_resolved(env, pkgspec, true)
-    Pkg3.Operations.add(env, pkgspec)
+    Pkg3.Operations.ensure_resolved(ctx.env, pkgspec, true)
+    Pkg3.Operations.add(ctx, pkgspec)
     return _find_package(name)
 end
-
-const query_if_interactive = Ref{Any}(_query_if_interactive)
 
 end # module

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -44,9 +44,7 @@ temp_pkg_dir() do project_path
     @test_broken Pkg3.test(TEST_PKG)
     Pkg3.test(TEST_PKG; preview = true)
 
-    Pkg3.GLOBAL_SETTINGS.use_libgit2_for_all_downloads = true
-    Pkg3.add("Example")
-    Pkg3.GLOBAL_SETTINGS.use_libgit2_for_all_downloads = false
+    Pkg3.add("Example"; use_libgit2_for_all_downloads = true)
 
     try
         Pkg3.add([PackageSpec(TEST_PKG, VersionSpec(v"55"))])


### PR DESCRIPTION
This contains settings and state that needs to be passed around

Removes the `GLOBAL_SETTINGS` struct.

Based on the comment in #122:

> A pretty large amount of options and state need to be passed around between all of these functions and that will only grow as we add more functionality to the interface. We should probably bite the bullet and have an type that wraps all of the options which can also have input, output and error streams in it.