### PR TITLE
refactor parsing using enums and structs and use enums in more places

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -27,7 +27,7 @@ function git_file_stream(repo::LibGit2.GitRepo, spec::String; fakeit::Bool=false
     return IOBuffer(LibGit2.rawcontent(blob))
 end
 
-function status(ctx::Context, mode::Symbol, use_as_api=false)
+function status(ctx::Context, mode::PackageMode; use_as_api=false)
     env = ctx.env
     project₀ = project₁ = env.project
     manifest₀ = manifest₁ = env.manifest
@@ -40,25 +40,25 @@ function status(ctx::Context, mode::Symbol, use_as_api=false)
         project₀ = read_project(git_file_stream(env.git, "HEAD:$project_path", fakeit=true))
         manifest₀ = read_manifest(git_file_stream(env.git, "HEAD:$manifest_path", fakeit=true))
     end
-    if mode == :project || mode == :combined
+    if mode == PKGMODE_PROJECT || mode == PKGMODE_COMBINED
         # TODO: handle project deps missing from manifest
         m₀ = filter_manifest(in_project(project₀["deps"]), manifest₀)
         m₁ = filter_manifest(in_project(project₁["deps"]), manifest₁)
-        @info "Status $(pathrepr(env, env.project_file))"
+        use_as_api || @info("Status $(pathrepr(env, env.project_file))")
         diff = manifest_diff(m₀, m₁)
         use_as_api || print_diff(diff)
     end
-    if mode == :manifest
-        @info "Status $(pathrepr(env, env.manifest_file))"
+    if mode == PKGMODE_MANIFEST
+        use_as_api || @info("Status $(pathrepr(env, env.manifest_file))")
         diff = manifest_diff(manifest₀, manifest₁)
         use_as_api || print_diff(diff)
-    elseif mode == :combined
+    elseif mode == PKGMODE_COMBINED
         p = !in_project(merge(project₀["deps"], project₁["deps"]))
         m₀ = filter_manifest(p, manifest₀)
         m₁ = filter_manifest(p, manifest₁)
         c_diff = filter!(x->x.old != x.new, manifest_diff(m₀, m₁))
         if !isempty(c_diff)
-            @info "Status $(pathrepr(env, env.manifest_file))"
+            use_as_api || @info("Status $(pathrepr(env, env.manifest_file))")
             use_as_api || print_diff(c_diff)
             diff = Base.vcat(c_diff, diff)
         end

--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -932,7 +932,7 @@ function check_constraints(graph::Graph)
             err_msg = "Resolve failed to satisfy requirements for package $(id(p0)):\n"
         end
         err_msg *= sprint(showlog, rlog, pkgs[p0])
-        throw(PkgError(err_msg))
+        throw(ResolverError(err_msg))
     end
     return true
 end
@@ -1002,7 +1002,7 @@ function propagate_constraints!(graph::Graph, sources::Set{Int} = Set{Int}(); lo
                         err_msg = "Resolve failed to satisfy requirements for package $(id(p1)):\n"
                     end
                     err_msg *= sprint(showlog, rlog, pkgs[p1])
-                    throw(PkgError(err_msg))
+                    throw(ResolverError(err_msg))
                 end
             end
         end
@@ -1079,7 +1079,7 @@ function deep_clean!(graph::Graph)
             try
                 propagate_constraints!(graph, Set{Int}([p0]), log_events = false)
             catch err
-                err isa PkgError || rethrow(err)
+                err isa ResolverError || rethrow(err)
                 gconstr_msk[p0][v0] = false
             end
             pop_snapshot!(graph)
@@ -1098,7 +1098,7 @@ function deep_clean!(graph::Graph)
             end
             if !any(gconstr0)
                 # TODO : what should we do here??
-                # throw(PkgError("aaaaaaaaaaaaaahhhhhhhh")) # XXX
+                # throw(ResolverError("aaaaaaaaaaaaaahhhhhhhh")) # XXX
             end
         end
         println("> affected = $(length(affected))")

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -529,7 +529,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     drop = UUID[]
     # find manifest-mode drops
     for pkg in pkgs
-        pkg.mode == :manifest || continue
+        pkg.mode == PKGMODE_MANIFEST || continue
         info = manifest_info(ctx.env, pkg.uuid)
         if info != nothing
             pkg.uuid in drop || push!(drop, pkg.uuid)
@@ -554,7 +554,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     end
     # find project-mode drops
     for pkg in pkgs
-        pkg.mode == :project || continue
+        pkg.mode == PKGMODE_PROJECT || continue
         found = false
         for (name::String, uuidstr::String) in ctx.env.project["deps"]
             uuid = UUID(uuidstr)
@@ -623,12 +623,12 @@ function up(ctx::Context, pkgs::Vector{PackageSpec})
         level = pkg.version
         info = manifest_info(ctx.env, pkg.uuid)
         ver = VersionNumber(info["version"])
-        if level == UpgradeLevel(:fixed)
+        if level == UPLEVEL_FIXED
             pkg.version = VersionNumber(info["version"])
         else
-            r = level == UpgradeLevel(:patch) ? VersionRange(ver.major, ver.minor) :
-                level == UpgradeLevel(:minor) ? VersionRange(ver.major) :
-                level == UpgradeLevel(:major) ? VersionRange() :
+            r = level == UPLEVEL_PATCH ? VersionRange(ver.major, ver.minor) :
+                level == UPLEVEL_MINOR ? VersionRange(ver.major) :
+                level == UPLEVEL_MAJOR ? VersionRange() :
                     error("unexpected upgrade level: $level")
             pkg.version = VersionSpec(r)
         end

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -34,31 +34,4 @@ function __init__()
     end
 end
 
-# TODO: Hook this up to the code loading and make it execute
-# when in interactive mode and a package is not found
-function query_if_interactive(base, name)
-    ctx = Types.Context()
-    pkgspec = [Types.PackageSpec(base)]
-
-    r = Operations.registry_resolve!(ctx.env, pkgspec)
-    Types.has_uuid(r[1]) || return nothing
-
-    ctx.load_error_choice == LOAD_ERROR_INSTALL && @goto install
-    ctx.load_error_choice == LOAD_ERROR_ERROR   && return nothing
-
-    choice = TerminalMenus.request("Could not find package \e[1m$(base)\e[22m, do you want to install it?",
-                   TerminalMenus.RadioMenu(["yes", "yes (remember)", "no", "no (remember)"]))
-
-    if choice == 3 || choice == 4
-        choice == 4 && (ctx.load_error_choice = LOAD_ERROR_ERROR)
-        return nothing
-    end
-
-    choice == 2 && (ctx.load_error_choice = LOAD_ERROR_INSTALL)
-    @label install
-    Pkg3.Operations.ensure_resolved(ctx.env, pkgspec, true)
-    Pkg3.Operations.add(ctx, pkgspec)
-    return _find_package(name)
-end
-
 end # module

--- a/src/Resolve.jl
+++ b/src/Resolve.jl
@@ -124,7 +124,7 @@ function sanity_check(graph::Graph, sources::Set{UUID} = Set{UUID}(); verbose = 
         try
             simplify_graph_soft!(graph, Set{Int}([p0]), log_events = false)
         catch err
-            isa(err, PkgError) || rethrow(err)
+            isa(err, ResolverError) || rethrow(err)
             @goto done
         end
 
@@ -222,7 +222,7 @@ function greedysolver(graph::Graph)
     try
         simplify_graph_soft!(graph, req_inds, log_events = false)
     catch err
-        err isa PkgError || rethrow(err)
+        err isa ResolverError || rethrow(err)
         pop_snapshot!(graph)
         return (false, Int[])
     end

--- a/src/resolve/MaxSum.jl
+++ b/src/resolve/MaxSum.jl
@@ -352,7 +352,7 @@ function try_simplify_graph_soft!(graph, sources)
     try
         simplify_graph_soft!(graph, sources, log_events = false)
     catch err
-        err isa PkgError || rethrow(err)
+        err isa ResolverError || rethrow(err)
         return false
     end
     return true

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -52,7 +52,7 @@ temp_pkg_dir() do project_path
     end
 
     @testset "package with wrong UUID" begin
-        @test_throws PkgError Pkg3.add(PackageSpec(TEST_PKG.name, UUID(UInt128(1))))
+        @test_throws ResolverError Pkg3.add(PackageSpec(TEST_PKG.name, UUID(UInt128(1))))
     end
 
     @testset "adding and upgrading different versions" begin

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -302,7 +302,7 @@ end
         ["A", "1"],
         ["C", "2-*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
 
     VERBOSE && @info("SCHEME 4")
@@ -352,7 +352,7 @@ end
     reqs_data = Any[
         ["A", "2-*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
 
     VERBOSE && @info("SCHEME 6")
@@ -371,13 +371,13 @@ end
     reqs_data = Any[
         ["A", "*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
     # require B (impossible)
     reqs_data = Any[
         ["B", "*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
 
     VERBOSE && @info("SCHEME 7")
@@ -412,7 +412,7 @@ end
     reqs_data = Any[
         ["C", "1"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
 
     VERBOSE && @info("SCHEME 8")
@@ -434,19 +434,19 @@ end
     reqs_data = Any[
         ["A", "*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
     # require B (impossible)
     reqs_data = Any[
         ["B", "*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
     # require C (impossible)
     reqs_data = Any[
         ["C", "*"]
     ]
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 
     VERBOSE && @info("SCHEME 9")
     ## DEPENDENCY SCHEME 9: SIX PACKAGES, DAG
@@ -583,7 +583,7 @@ end
     deps_data, reqs_data, want_data, problematic_data = NastyGenerator.generate_nasty(5, 20, q=20, d=4, sat = false)
 
     @test sanity_tst(deps_data, problematic_data)
-    @test_throws PkgError resolve_tst(deps_data, reqs_data)
+    @test_throws ResolverError resolve_tst(deps_data, reqs_data)
 end
 
 end # module


### PR DESCRIPTION
* Refactors the parsing for REPLMode. Instead of each token being a `Tuple{Symbol, Vararg{Any}}` it is now just a `Token` which is defined as `const Token = Union{Command, Option, VersionRange, String}`. `Command` is a struct representing a command like `add`, `Option` is a struct representing an option like `--path=foo` or `--manifest`. There is no more `pkg`-token because it is not up to the lexer to decide if a word is a path or a package because it is context sensitive. Instead just lex those as a `String` and try to parse it as a package when it is expected in different commands. This makes the quotes not needed in paths and urls anymore.

Also uses enums instead of symbols in more places where there are a finite set of choices.

Also fixes not printing some stuff when using `status` in API mode.

Sorry for bundling some random stuff together...