### PR TITLE
implement checkout

### DIFF
--- a/bin/loadmeta.jl
+++ b/bin/loadmeta.jl
@@ -3,12 +3,11 @@
 using Base: thispatch, thisminor, nextpatch, nextminor
 import LinearAlgebra: checksquare
 import UUIDs
+import Pkg3
 using Pkg3.Types
 using Pkg3.Types: uuid_package, uuid_registry, uuid5
-
-include("Pkg2/Pkg2.jl")
-import .Pkg2.Reqs: Reqs, Requirement
-import .Pkg2.Types: VersionInterval
+import Pkg3.Pkg2.Reqs: Reqs, Requirement
+import Pkg3.Pkg2.Pkg2Types: VersionInterval
 
 ## Loading data into various data structures ##
 
@@ -143,7 +142,7 @@ end
 
 ## Load package data ##
 
-const pkgs = load_packages(Pkg2.dir("METADATA"))
+const pkgs = load_packages(Pkg3.Pkg2.dir("METADATA"))
 # delete packages whose repos that no longer exist:
 for pkg in [
     "CardinalDicts"

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -88,14 +88,16 @@ function print_manifest_diff(env₀::EnvCache, env₁::EnvCache)
 end
 
 struct VerInfo
-    hash::SHA1
+    hash::Union{SHA1,Nothing}
+    path::Union{String,Nothing}
     ver::Union{VersionNumber,Nothing}
     pinned::Bool
 end
 
 vstring(a::VerInfo) =
     string(a.ver == nothing ? "[$(string(a.hash)[1:16])]" : "v$(a.ver)",
-           a.pinned == true ? "⚲" : "")
+           a.pinned == true ? "⚲" : "",
+           a.path != nothing ? " [$(a.path)]" : "")
 
 Base.:(==)(a::VerInfo, b::VerInfo) =
     a.hash == b.hash && a.ver == b.ver && a.pinned == b.pinned
@@ -166,10 +168,11 @@ end
 
 function name_ver_info(info::Dict)
     name = info["name"]
-    hash = haskey(info, "git-tree-sha1") ? SHA1(info["git-tree-sha1"]) : nothing
-    ver = haskey(info, "version") ? VersionNumber(info["version"]) : nothing
-    pin = get(info, "pinned", false)
-    name, VerInfo(hash, ver, pin)
+    hash = haskey(info, "git-tree-sha1") ? SHA1(info["git-tree-sha1"])    : nothing
+    ver  = haskey(info, "version")       ? VersionNumber(info["version"]) : nothing
+    path =  get(info, "path", nothing)
+    pin  =  get(info, "pinned", false)
+    name, VerInfo(hash, path, ver, pin)
 end
 
 function manifest_diff(manifest₀::Dict, manifest₁::Dict)

--- a/src/GraphType.jl
+++ b/src/GraphType.jl
@@ -313,6 +313,7 @@ mutable struct Graph
         adjdict = [Dict{Int,Int}() for p0 = 1:np]
 
         for p0 = 1:np, v0 = 1:(spp[p0]-1), (p1,rmsk1) in extended_deps[p0][v0]
+            @assert p0 ≠ p1
             j0 = get(adjdict[p1], p0, length(gadj[p0]) + 1)
             j1 = get(adjdict[p0], p1, length(gadj[p1]) + 1)
 

--- a/src/Pkg2/Pkg2.jl
+++ b/src/Pkg2/Pkg2.jl
@@ -2,27 +2,6 @@
 
 module Pkg2
 
-struct PkgError <: Exception
-    msg::AbstractString
-    ex::Union{Exception, Nothing}
-end
-PkgError(msg::AbstractString) = PkgError(msg, nothing)
-function Base.showerror(io::IO, pkgerr::PkgError)
-    print(io, pkgerr.msg)
-    if pkgerr.ex !== nothing
-        pkgex = get(pkgerr.ex)
-        if isa(pkgex, CompositeException)
-            for cex in pkgex
-                print(io, "\n=> ")
-                showerror(io, cex)
-            end
-        else
-            print(io, "\n")
-            showerror(io, pkgex)
-        end
-    end
-end
-
 # DIR
 const DIR_NAME = ".julia"
 _pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))

--- a/src/Pkg2/reqs.jl
+++ b/src/Pkg2/reqs.jl
@@ -3,8 +3,7 @@
 module Reqs
 
 import Base: ==
-import ..PkgError
-using ..Types
+using ..Pkg2Types
 
 # representing lines of REQUIRE files
 
@@ -42,5 +41,6 @@ function read(readable::Union{IO,Base.AbstractCmd})
     return lines
 end
 read(file::AbstractString) = isfile(file) ? open(read,file) : Line[]
+
 
 end # module

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -7,12 +7,14 @@ using REPL.TerminalMenus
 
 depots() = Base.DEPOT_PATH
 logdir() = joinpath(depots()[1], "logs")
+devdir() = get(ENV, "JULIA_PKG_DEVDIR", joinpath(homedir(), ".julia", "dev"))
 
 # load snapshotted dependencies
 include("../ext/TOML/src/TOML.jl")
 
 include("PlatformEngines.jl")
 include("Types.jl")
+include("Pkg2/Pkg2.jl")
 include("GraphType.jl")
 include("Resolve.jl")
 include("Display.jl")
@@ -20,7 +22,7 @@ include("Operations.jl")
 include("REPLMode.jl")
 include("API.jl")
 
-import .API: add, rm, up, test, gc, init, build, installed, pin, free
+import .API: add, rm, up, test, gc, init, build, installed, pin, free, checkout
 const update = up
 
 function __init__()

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -23,7 +23,7 @@ export UUID, pkgID, SHA1, VersionRange, VersionSpec, empty_versionspec,
     read_project, read_manifest, pathrepr, registries,
     PackageMode, PKGMODE_MANIFEST, PKGMODE_PROJECT, PKGMODE_COMBINED,
     UpgradeLevel, UPLEVEL_FIXED, UPLEVEL_PATCH, UPLEVEL_MINOR, UPLEVEL_MAJOR,
-    PackageSpecialAction, PKGSPEC_NOTHING, PKGSPEC_PINNED, PKGSPEC_FREED
+    PackageSpecialAction, PKGSPEC_NOTHING, PKGSPEC_PINNED, PKGSPEC_FREED, PKGSPEC_CHECKED_OUT
 
 
 ## ordering of UUIDs ##
@@ -376,7 +376,7 @@ function UpgradeLevel(s::Symbol)
 end
 
 @enum(PackageMode, PKGMODE_PROJECT, PKGMODE_MANIFEST, PKGMODE_COMBINED)
-@enum(PackageSpecialAction, PKGSPEC_NOTHING, PKGSPEC_PINNED, PKGSPEC_FREED)
+@enum(PackageSpecialAction, PKGSPEC_NOTHING, PKGSPEC_PINNED, PKGSPEC_FREED, PKGSPEC_CHECKED_OUT)
 
 const VersionTypes = Union{VersionNumber,VersionSpec,UpgradeLevel}
 
@@ -385,11 +385,12 @@ mutable struct PackageSpec
     uuid::UUID
     version::VersionTypes
     mode::PackageMode
+    path::Union{Nothing, String}
     special_action::PackageSpecialAction # If the package is currently being pinned, freed etc
-    PackageSpec(name::String, uuid::UUID, version::VersionTypes, mode::PackageMode=PKGMODE_PROJECT, special_action=PKGSPEC_NOTHING) =
-        new(name, uuid, version, mode, special_action)
+    PackageSpec(name::AbstractString, uuid::UUID, version::VersionTypes, mode::PackageMode=PKGMODE_PROJECT, path=nothing, special_action=PKGSPEC_NOTHING) =
+        new(String(name), uuid, version, mode, path, special_action)
 end
-PackageSpec(name::String, uuid::UUID) =
+PackageSpec(name::AbstractString, uuid::UUID) =
     PackageSpec(name, uuid, VersionSpec())
 PackageSpec(name::AbstractString, version::VersionTypes=VersionSpec()) =
     PackageSpec(name, UUID(zero(UInt128)), version)


### PR DESCRIPTION
Backwards compatible with REQUIRE files. Can choose branch and path to checkout to. Perhaps repo should be choosable too...

There seems to be some problem with finding the Test module when testing a checked out package. Building works fine though:

```
pkg> checkout Example
[ Info: Checking out Example [7876af07]
[ Info: Cloning Example from https://github.com/JuliaLang/Example.jl.git to /Users/kristoffer/.julia/dev
[ Info: Resolving package versions
[ Info: Updating "~/.julia/environments/v0.7/Project.toml"
 [7876af07] + Example v0.5.1+ [/Users/kristoffer/.julia/dev/Example]
[ Info: Updating "~/.julia/environments/v0.7/Manifest.toml"
 [7876af07] + Example v0.5.1+ [/Users/kristoffer/.julia/dev/Example]

pkg> test Example
[ Info: Testing Example located at /Users/kristoffer/.julia/dev/Example
ERROR: LoadError: ArgumentError: Module Test not found in current path.
Run `Pkg.add("Test")` to install the Test package.
Stacktrace:
 [1] require(::Module, ::Symbol) at ./loading.jl:861
 [2] top-level scope at /Users/kristoffer/.julia/dev/Example/test/runtests.jl:5
 [3] include at ./boot.jl:295 [inlined]
 [4] include_relative(::Module, ::String) at ./loading.jl:1064
 [5] top-level scope
in expression starting at /Users/kristoffer/.julia/dev/Example/test/runtests.jl:5
ERROR: Package Example errored during testing
```