### PR TITLE
allow packages to load dependencies at top level when building or testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_script:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Pkg3"); Pkg.test("Pkg3"; coverage=true)'
+  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Pkg3"); rm(Pkg.dir("Pkg3", "Project.toml"));
+                                 withenv("JULIA_LOAD_PATH" => Pkg.dir()) do; Pkg.test("Pkg3"; coverage=true); end'
 
 after_success:
   - julia -e 'cd(Pkg.dir("Pkg3")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/API.jl
+++ b/src/API.jl
@@ -334,7 +334,7 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     uuids = UUID[]
     _get_deps!(ctx, pkgs, uuids)
     length(uuids) == 0 && (@info("no packages to build"); return)
-    Pkg3.Operations.build_versions(ctx, uuids)
+    Pkg3.Operations.build_versions(ctx, uuids; do_resolve=true)
 end
 
 init() = init(Context())

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -432,7 +432,7 @@ const default_envs = [
     "default",
 ]
 
-struct EnvCache
+mutable struct EnvCache
     # environment info:
     env::Union{Nothing,String,AbstractEnv}
     git::Union{Nothing,LibGit2.GitRepo}
@@ -928,7 +928,7 @@ function Context!(ctx::Context; kwargs...)
     end
 end
 
-function write_env(ctx::Context)
+function write_env(ctx::Context; no_output=false)
     env = ctx.env
     # load old environment for comparison
     old_env = EnvCache(env.env)
@@ -936,8 +936,8 @@ function write_env(ctx::Context)
     project = deepcopy(env.project)
     isempty(project["deps"]) && delete!(project, "deps")
     if !isempty(project) || ispath(env.project_file)
-        @info "Updating $(pathrepr(env, env.project_file))"
-        Pkg3.Display.print_project_diff(old_env, env)
+        no_output || @info "Updating $(pathrepr(env, env.project_file))"
+        no_output || Pkg3.Display.print_project_diff(old_env, env)
         if !ctx.preview
             mkpath(dirname(env.project_file))
             open(env.project_file, "w") do io
@@ -947,8 +947,8 @@ function write_env(ctx::Context)
     end
     # update the manifest file
     if !isempty(env.manifest) || ispath(env.manifest_file)
-        @info "Updating $(pathrepr(env, env.manifest_file))"
-        Pkg3.Display.print_manifest_diff(old_env, env)
+        no_output || @info "Updating $(pathrepr(env, env.manifest_file))"
+        no_output || Pkg3.Display.print_manifest_diff(old_env, env)
         manifest = deepcopy(env.manifest)
         uniques = sort!(collect(keys(manifest)), by=lowercase)
         filter!(name->length(manifest[name]) == 1, uniques)


### PR DESCRIPTION
Fixes #152 cc @bicycle1885 @StefanKarpinski 

```
pkg> add EzXML
[ Info: Resolving package versions
[ Info: Installed Compat ───────── v0.54.0
[ Info: Installed BinaryProvider ─ v0.2.3
[ Info: Installed DataStructures ─ v0.7.4
[ Info: Installed EzXML ────────── v0.6.1
[ Info: Updating "~/.julia/environments/v0.7/Project.toml"
 [8f5d6c58] + EzXML v0.6.1
[ Info: Updating "~/.julia/environments/v0.7/Manifest.toml"
 [b99e7846] + BinaryProvider v0.2.3
 [8f5d6c58] + EzXML v0.6.1
[ Info: Building EzXML [e021a23d]...
[ Info:  → /Users/kristoffer/.julia/packages/EzXML/taEy/deps/build.log

pkg> test EzXML
[ Info: Testing EzXML located at /Users/kristoffer/.julia/packages/EzXML/taEy
[DEPRECATIONS...]
Test Summary: | Pass  Total
Error         |   88     88
....
```