### PR TITLE
test and fix libgit2 download of registered packages

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -377,6 +377,7 @@ end
 
 const refspecs = ["+refs/*:refs/remotes/cache/*"]
 function install_git(
+    ctx::Context,
     uuid::UUID,
     name::String,
     hash::SHA1,
@@ -403,8 +404,7 @@ function install_git(
         LibGit2.fetch(repo, remoteurl=url, refspecs=refspecs)
     end
     tree = try
-        with(LibGit2.GitObject, repo, git_hash) do g
-        end
+        LibGit2.GitObject(repo, git_hash)
     catch err
         err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
         error("$name: git object $(string(hash)) could not be found")
@@ -417,7 +417,7 @@ function install_git(
         target_directory = Base.unsafe_convert(Cstring, version_path)
     )
     LibGit2.checkout_tree(repo, tree, options=opts)
-    close(repo); close(tree); close(opts); close(git_hash)
+    close(repo); close(tree)
     return
 end
 
@@ -493,7 +493,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec})::Vector{UUID}
     for (pkg, path) in missed_packages
         uuid = pkg.uuid
         if !ctx.preview
-            install_git(pkg.uuid, pkg.name, hashes[uuid], urls[uuid], pkg.version::VersionNumber, path)
+            install_git(ctx, pkg.uuid, pkg.name, hashes[uuid], urls[uuid], pkg.version::VersionNumber, path)
         end
         vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
         @info "Installed $(rpad(pkg.name * " ", max_name + 2, "─")) $vstr"

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -16,7 +16,6 @@ include("utils.jl")
 const TEST_PKG = (name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
 
 temp_pkg_dir() do project_path
-
     @testset "simple add and remove with preview" begin
         Pkg3.init(project_path)
         Pkg3.add(TEST_PKG.name; preview = true)
@@ -144,6 +143,14 @@ temp_pkg_dir() do project_path
     end
 
     Pkg3.rm(TEST_PKG.name)
+end
+
+temp_pkg_dir() do project_path
+    @testset "libgit2 downloads" begin
+        Pkg3.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
+        @test haskey(Pkg3.installed(), TEST_PKG.name)
+        Pkg3.rm(TEST_PKG.name)
+    end
 end
 
 include("repl.jl")

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -86,7 +86,6 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
         Pkg3.REPLMode.pkgstr("add $p2#$c")
     end
 
-    # TODO cleanup
     mktempdir() do tmp_dev_dir
     withenv("JULIA_PKG_DEVDIR" => tmp_dev_dir) do
         pkg"develop Example"


### PR DESCRIPTION
Test for downloading registered packages with LibGit2 had gone missing and, of course, is now broken. Fix this and add the test.