### PR TITLE
Avoid overwriting user-defined settings in REPL

### DIFF
--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -53,7 +53,7 @@ function __init__()
     else
         atreplinit() do repl
             if isinteractive() && repl isa REPL.LineEditREPL
-                repl.interface = REPL.setup_interface(repl)
+                isdefined(repl, :interface) || (repl.interface = REPL.setup_interface(repl))
                 REPLMode.repl_init(repl)
             end
         end


### PR DESCRIPTION
Without this my custom REPL settings from `.julia/config/startup.jl` get overwritten, because keybinding customization is done by calling `REPL.setup_interface` too, cf. https://docs.julialang.org/en/latest/stdlib/REPL/#Customizing-keybindings-1, and it runs before Pkg3 is loaded.