### PR TITLE
fix some printing inconsistencies

### DIFF
--- a/src/Display.jl
+++ b/src/Display.jl
@@ -81,7 +81,7 @@ end
 function print_project_diff(ctx::Context, env₀::EnvCache, env₁::EnvCache)
     pm₀ = filter_manifest(in_project(env₀.project["deps"]), env₀.manifest)
     pm₁ = filter_manifest(in_project(env₁.project["deps"]), env₁.manifest)
-    diff = filter!(x->x.old != x.new, manifest_diff(ctx, pm₀, pm₁))
+     diff = filter!(x->x.old != x.new, manifest_diff(ctx, pm₀, pm₁))
     if isempty(diff)
         printstyled(color = color_dark, " [no changes]\n")
     else
@@ -118,11 +118,12 @@ vstring(ctx::Context, a::VerInfo) =
            )
 
 Base.:(==)(a::VerInfo, b::VerInfo) =
-    a.hash == b.hash && a.ver == b.ver && a.pinned == b.pinned
+    a.hash == b.hash && a.ver == b.ver && a.pinned == b.pinned && a.repo == b.repo
 
 ≈(a::VerInfo, b::VerInfo) = a.hash == b.hash &&
     (a.ver == nothing || b.ver == nothing || a.ver == b.ver) &&
-    (a.pinned == b.pinned)
+    (a.pinned == b.pinned) &&
+    (a.repo == nothing || b.repo == nothing || a.repo == b.repo)
 
 struct DiffEntry
     uuid::UUID
@@ -154,7 +155,7 @@ function print_diff(io::IO, ctx::Context, diff::Vector{DiffEntry})
                         "versions match but hashes don't: $(x.old.hash) ≠ $(x.new.hash)"
                     push!(warnings, msg)
                 end
-                vstr = (x.old.ver == x.new.ver && x.old.pinned == x.new.pinned) ?
+                vstr = (x.old.ver == x.new.ver && x.old.pinned == x.new.pinned && x.old.repo == x.new.repo) ?
                       vstring(ctx, x.new) :
                       vstring(ctx, x.old) * " ⇒ " * vstring(ctx, x.new)
             end

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -81,7 +81,7 @@ end
 function print_project_diff(ctx::Context, env₀::EnvCache, env₁::EnvCache)
     pm₀ = filter_manifest(in_project(env₀.project["deps"]), env₀.manifest)
     pm₁ = filter_manifest(in_project(env₁.project["deps"]), env₁.manifest)
-     diff = filter!(x->x.old != x.new, manifest_diff(ctx, pm₀, pm₁))
+    diff = filter!(x->x.old != x.new, manifest_diff(ctx, pm₀, pm₁))
     if isempty(diff)
         printstyled(color = color_dark, " [no changes]\n")
     else

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -384,6 +384,7 @@ end
 
 GitRepo(url::String, revspec) = GitRepo(url, revspec, nothing)
 GitRepo(url::String) = GitRepo(url, "", nothing)
+Base.:(==)(repo1::GitRepo, repo2::GitRepo) = (repo1.url == repo2.url && repo1.rev == repo2.rev && repo1.git_tree_sha1 == repo2.git_tree_sha1)
 
 mutable struct PackageSpec
     name::String


### PR DESCRIPTION
```
(Pkg3) pkg> add Literate#b57e6cc
...
  Updating `Project.toml`
 [98b081ad] ~ Literate v0.1.0+ #master ⇒ v0.1.0+ #b57e6cc
  Updating `Manifest.toml`
 [98b081ad] ~ Literate v0.1.0+ #master ⇒ v0.1.0+ #b57e6cc

(Pkg3) pkg> add Revise#master
...
   Updating `Project.toml`
 [295af30f] ~ Revise v0.3.0+ #7350aff ⇒ v0.3.0+ #master
  Updating `Manifest.toml`
 [295af30f] ~ Revise v0.3.0+ #7350aff ⇒ v0.3.0+ #master
```

Fixes #271 