### PR TITLE
no longer collect dependencies from the registry for fixed packages

### DIFF
--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -159,7 +159,7 @@ function collect_require!(ctx::Context, pkg::PackageSpec, path::String, fix_deps
             pkg_name, vspec = r.package, VersionSpec(VersionRange[r.versions.intervals...])
             if pkg_name == "julia"
                 if !(VERSION in vspec)
-                    error("julia version requirement for package $pkg not satisfied")
+                    @warn("julia version requirement for package $pkg not satisfied")
                 end
             else
                 deppkg = PackageSpec(pkg_name, vspec)
@@ -198,6 +198,7 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Require
         isempty(unseen) && break
         for uuid in unseen
             push!(seen, uuid)
+            uuid in keys(fixed) && continue
             all_versions_u = get_or_make!(all_versions, uuid)
             all_deps_u     = get_or_make!(all_deps,     uuid)
             all_compat_u   = get_or_make!(all_compat,   uuid)


### PR DESCRIPTION
Does this make sense to you @carlobaldassi? We have already collected the dependencies for the fixed versions, no need to go to the registry at all and collect dependencies for other versions?

Fixes #270.

```
(Pkg3) pkg> dev DataStreams
 Resolving package versions...
Downloaded WeakRefStrings ─ v0.4.6
Downloaded Nullables ────── v0.0.5
Downloaded JSON ─────────── v0.17.2
Downloaded Missings ─────── v0.2.9
Downloaded DataStructures ─ v0.8.1
  Updating `Project.toml`
 [9a8bc11e] + DataStreams v0.3.4+ [`~/.julia/dev/DataStreams`]
  Updating `Manifest.toml`
 [9a8bc11e] + DataStreams v0.3.4+ [`~/.julia/dev/DataStreams`]
 [e1d29d7a] + Missings v0.2.9
 [ea10d353] + WeakRefStrings v0.4.6
```