### PR TITLE
implement instantiate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ branches:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"")); import Pkg3; Pkg3.build(); Pkg3.test(; coverage=true)'
+  - julia --check-bounds=yes -e 'using UUIDs; write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\""));
+                                 import Pkg3; Pkg3.instantiate(); Pkg3.test(; coverage=true)'
 
 after_success:
   - julia -e 'import Pkg3; Pkg3.add("Documenter"); include("docs/make.jl")'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
-# We swap the uuid for Pkg3 here to make it not load the stdlib
+# We swap the uuid for Pkg3 here to make it not load the stdlib version of Pkg3
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
       using UUIDs;
@@ -38,7 +38,7 @@ build_script:
       after = replace(before, \"uuid = \\\"44cfe95a-1eb2-52ea-b672-e2afdf69b78f\\\"\" =>
                               \"uuid = \\\"4d836010-47a6-11e8-12b2-0918962bae33\\\"\");
       write(\"Project.toml\", after);
-      import Pkg3; Pkg3.build()"
+      import Pkg3; Pkg3.instantiate()"
 
 test_script:
   - C:\projects\julia\bin\julia -e "import Pkg3; Pkg3.test(; coverage=true)"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -373,7 +373,7 @@ Developed packages are never touched by the package manager.
 If you just want install the packages that are given by the current `Manifest.toml` use
 
 ```
-(HelloWorld) pkg> up --manifest --fixed
+(HelloWorld) pkg> instantiate
 ```
 
 ## Precompiling the project
@@ -409,9 +409,10 @@ However, nothing would be installed and your `Project.toml` and `Manfiest.toml` 
 Simple clone their project using e.g. `git clone`, `cd` to the project directory and call
 
 ```
-(SomeProject) pkg> up --manifest --fixed
+(SomeProject) pkg> instantiate
 ```
 
-This will install the packages at the same state that the project you cloned was using.
+If the project contains a manifest, this will install the packages at the same state that is given by that manifest.
+Otherwise it will resolve the latest versions of the dependencies compatible with the project.
 
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -118,7 +118,8 @@ function update_registry(ctx)
     return
 end
 
-up(;kwargs...)                                 = up(PackageSpec[]; kwargs...)
+up(ctx::Context; kwargs...)                    = up(ctx, PackageSpec[]; kwargs...)
+up(; kwargs...)                                = up(PackageSpec[]; kwargs...)
 up(pkg::Union{String, PackageSpec}; kwargs...) = up([pkg]; kwargs...)
 up(pkgs::Vector{String}; kwargs...)            = up([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
 up(pkgs::Vector{PackageSpec}; kwargs...)       = up(Context(), pkgs; kwargs...)
@@ -416,7 +417,7 @@ function dir(pkg::String, paths::String...)
     return joinpath(abspath(path, "..", "..", paths...))
 end
 
-
+precompile() = precompile(Context())
 function precompile(ctx::Context)
     printpkgstyle(ctx, :Precompiling, "project...")
 
@@ -471,6 +472,52 @@ function precompile(ctx::Context)
         ```)))
     end
     return nothing
+end
+
+
+function read_package_from_manifest!(pkg::PackageSpec, info::Dict)
+    pkg.uuid = UUID(info["uuid"])
+    pkg.path = get(info, "path", nothing)
+    if haskey(info, "repo-url")
+        pkg.repo = Types.GitRepo(info["repo-url"], info["repo-rev"])
+    end
+    haskey(info, "version") && (pkg.version = VersionNumber(info["version"]))
+end
+
+instantiate(; kwargs...) = instantiate(Context(); kwargs...)
+function instantiate(ctx::Context; manifest::Union{Bool, Nothing}=nothing, kwargs...)
+    Context!(ctx; kwargs...)
+    if (!isfile(ctx.env.manifest_file) && manifest == nothing) || manifest == false
+        up(ctx)
+        return
+    end
+    if !isfile(ctx.env.manifest_file) && manifest == true
+        cmderror("manifest at $(ctx.env.manifest) does not exist")
+    end
+    update_registry(ctx)
+    urls = Dict{}
+    hashes = Dict{UUID,SHA1}()
+    urls = Dict{UUID,Vector{String}}()
+    pkgs = PackageSpec[]
+    for (pkg_name, pkg_info) in ctx.env.manifest
+        for info in pkg_info
+            pkg = PackageSpec(pkg_name)
+            read_package_from_manifest!(pkg, info)
+            push!(pkgs, pkg)
+            pkg.uuid in keys(ctx.stdlibs) && continue
+            pkg.path !== nothing && continue
+            urls[pkg.uuid] = String[]
+            hashes[pkg.uuid] = SHA1(info["git-tree-sha1"])
+        end
+    end
+    _, urls_ref = Operations.version_data!(ctx, pkgs)
+    for (uuid, url) in urls_ref
+        append!(urls[uuid], url)
+        urls[uuid] = unique(urls[uuid])
+    end
+    new_git = handle_repos_add!(ctx, pkgs; upgrade_or_add=true)
+    new_apply = Operations.apply_versions(ctx, pkgs, hashes, urls)
+    Operations.build_versions(ctx, union(new_apply, new_git))
 end
 
 end # module

--- a/src/Display.jl
+++ b/src/Display.jl
@@ -53,14 +53,14 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
         diff = manifest_diff(ctx, m₀, m₁)
         if !use_as_api
             printpkgstyle(ctx, :Status, pathrepr(ctx, env.project_file); ignore_indent=true)
-            print_diff(ctx, diff)
+            print_diff(ctx, diff; status = true)
         end
     end
     if mode == PKGMODE_MANIFEST
         diff = manifest_diff(ctx, manifest₀, manifest₁)
         if !use_as_api
             printpkgstyle(ctx, :Status, pathrepr(ctx, env.manifest_file); ignore_indent=true)
-            print_diff(ctx, diff)
+            print_diff(ctx, diff; status = true)
         end
     elseif mode == PKGMODE_COMBINED
         p = not_in_project(merge(project₀["deps"], project₁["deps"]))
@@ -70,7 +70,7 @@ function status(ctx::Context, mode::PackageMode, use_as_api=false)
         if !isempty(c_diff)
             if !use_as_api
                 printpkgstyle(ctx, :Status, pathrepr(ctx, env.manifest_file); ignore_indent=true)
-                print_diff(ctx, c_diff)
+                print_diff(ctx, c_diff; status = true)
             end
             diff = Base.vcat(c_diff, diff)
         end
@@ -113,7 +113,7 @@ vstring(ctx::Context, a::VerInfo) =
     string((a.ver == nothing && a.hash != nothing) ? "[$(string(a.hash)[1:16])]" : "",
            a.ver != nothing ? "v$(a.ver)" : "",
            a.path != nothing ? " [$(pathrepr(ctx, a.path))]" : "",
-           a.repo != nothing ? " #$(revstring(a.repo.rev))" : "",
+           a.repo != nothing ? " #$(revstring(a.repo.rev)) [$(a.repo.url)]" : "",
            a.pinned == true ? " ⚲" : "",
            )
 
@@ -132,10 +132,12 @@ struct DiffEntry
     new::Union{VerInfo,Nothing}
 end
 
-function print_diff(io::IO, ctx::Context, diff::Vector{DiffEntry})
+function print_diff(io::IO, ctx::Context, diff::Vector{DiffEntry}; status=false)
     same = all(x.old == x.new for x in diff)
+    some_packages_not_downloaded = false
     for x in diff
-        warnings = String[]
+        package_downloaded = Base.locate_package(Base.PkgId(x.uuid, x.name)) !== nothing
+        package_downloaded || (some_packages_not_downloaded = true)
         if x.old != nothing && x.new != nothing
             if x.old ≈ x.new
                 verb = ' '
@@ -150,10 +152,6 @@ function print_diff(io::IO, ctx::Context, diff::Vector{DiffEntry})
                     verb = '~'
                 else
                     verb = '?'
-                    msg = x.old.hash == x.new.hash ?
-                        "hashes match but versions don't: $(x.old.ver) ≠ $(x.new.ver)" :
-                        "versions match but hashes don't: $(x.old.hash) ≠ $(x.new.hash)"
-                    push!(warnings, msg)
                 end
                 vstr = (x.old.ver == x.new.ver && x.old.pinned == x.new.pinned && x.old.repo == x.new.repo) ?
                       vstring(ctx, x.new) :
@@ -170,12 +168,20 @@ function print_diff(io::IO, ctx::Context, diff::Vector{DiffEntry})
             vstr = "[unknown]"
         end
         v = same ? "" : " $verb"
+        if verb != '-' && status == true && !package_downloaded
+            printstyled(io, "→", color=:red)
+        else
+            print(io, " ")
+        end
         printstyled(io, " [$(string(x.uuid)[1:8])]"; color = color_dark)
         printstyled(io, "$v $(x.name) $vstr\n"; color = colors[verb])
     end
+    if status == true && some_packages_not_downloaded
+        @warn "Some packages (indicated with a red arrow) are not downloaded, use `instantiate` to instantiate the current environment"
+    end
 end
 # TODO: Use the Context stream
-print_diff(ctx::Context, diff::Vector{DiffEntry}) = print_diff(stdout, ctx, diff)
+print_diff(ctx::Context, diff::Vector{DiffEntry}; kwargs...) = print_diff(stdout, ctx, diff; kwargs...)
 
 function manifest_by_uuid(manifest::Dict)
     entries = Dict{UUID,Dict}()

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -450,8 +450,12 @@ end
 
 # install & update manifest
 function apply_versions(ctx::Context, pkgs::Vector{PackageSpec})::Vector{UUID}
-    BinaryProvider.probe_platform_engines!()
     hashes, urls = version_data!(ctx, pkgs)
+    apply_versions(ctx, pkgs, hashes, urls)
+end
+
+function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UUID,SHA1}, urls::Dict{UUID,Vector{String}})
+    BinaryProvider.probe_platform_engines!()
     new_versions = UUID[]
 
     pkgs_to_install = Tuple{PackageSpec, String}[]

--- a/src/Pkg3.jl
+++ b/src/Pkg3.jl
@@ -41,7 +41,8 @@ include("Operations.jl")
 include("API.jl")
 include("REPLMode.jl")
 
-import .API: add, rm, up, test, gc, init, build, installed, pin, free, checkout, develop, generate
+import .API: add, rm, up, test, gc, init, build, installed, pin, free, checkout, develop, generate, instantiate
+import .Display: status
 const update = up
 # legacy CI script support
 import .API: clone, dir

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -14,7 +14,8 @@ using ..Types, ..Display, ..Operations
 ############
 @enum(CommandKind, CMD_HELP, CMD_STATUS, CMD_SEARCH, CMD_ADD, CMD_RM, CMD_UP,
                    CMD_TEST, CMD_GC, CMD_PREVIEW, CMD_INIT, CMD_BUILD, CMD_FREE,
-                   CMD_PIN, CMD_CHECKOUT, CMD_DEVELOP, CMD_GENERATE, CMD_PRECOMPILE)
+                   CMD_PIN, CMD_CHECKOUT, CMD_DEVELOP, CMD_GENERATE, CMD_PRECOMPILE,
+                   CMD_INSTANTIATE)
 
 struct Command
     kind::CommandKind
@@ -53,6 +54,7 @@ const cmds = Dict(
     "dev"       => CMD_DEVELOP,
     "generate"  => CMD_GENERATE,
     "precompile" => CMD_PRECOMPILE,
+    "instantiate" => CMD_INSTANTIATE,
 )
 
 #################
@@ -284,6 +286,7 @@ function do_cmd!(tokens::Vector{Token}, repl)
     cmd.kind == CMD_FREE     ? Base.invokelatest(          do_free!, ctx, tokens) :
     cmd.kind == CMD_GENERATE ? Base.invokelatest(      do_generate!, ctx, tokens) :
     cmd.kind == CMD_PRECOMPILE ? Base.invokelatest(  do_precompile!, ctx, tokens) :
+    cmd.kind == CMD_INSTANTIATE ? Base.invokelatest(do_instantiate!, ctx, tokens) :
         cmderror("`$cmd` command not yet implemented")
     return
 end
@@ -342,6 +345,8 @@ What action you want the package manager to take:
 `free`: undoes a `pin`, `develop`, or stops tracking a repo.
 
 `precompile`: precompile all the project dependencies
+
+`instantiate`: downloads all the dependencies for the project
 """
 
 const helps = Dict(
@@ -384,6 +389,9 @@ const helps = Dict(
     may be specified by `@1`, `@1.2`, `@1.2.3`, allowing any version with a prefix
     that matches, or ranges thereof, such as `@1.2-3.4.5`. A git-revision can be
     specified by `#branch` or `#commit`.
+
+    If a local path is used as an argument to `add`, the path needs to be a git repository.
+    The project will then track that git repository just like if it is was tracking a remote repository online.
 
     **Examples**
     ```
@@ -489,6 +497,13 @@ const helps = Dict(
         precompile
 
     Precompile all the dependencies of the project by running `import` on all of them in a new process.
+    """, CMD_INSTANTIATE => md"""
+        instantaite
+        instantiate [-m|--manifest]
+        instantiate [-p|--project]
+
+    Download all the dependencies for the current project at the version given by the project's manifest.
+    If no manifest exists or the `--project` option is given, resolve and download the dependencies compatible with the project.
     """
 )
 
@@ -742,6 +757,24 @@ function do_precompile!(ctx::Context, tokens::Vector{Token})
         cmderror("`precompile` does not take any arguments")
     end
     API.precompile(ctx)
+end
+
+function do_instantiate!(ctx::Context, tokens::Vector{Token})
+    manifest = nothing
+    for token in tokens
+        if token isa Option
+            if token.kind == OPT_MANIFEST
+                manifest = true
+            elseif token.kind == OPT_PROJECT
+            manifest = false
+            else
+                cmderror("invalid option for `instantiate`: $(token)")
+            end
+        else
+            cmderror("invalid argument for `instantiate` :$(token)")
+        end
+    end
+    API.instantiate(ctx; manifest=manifest)
 end
 
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -105,7 +105,7 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
                 write("Manifest.toml", manifest)
                 mktempdir() do depot_dir
                     pushfirst!(DEPOT_PATH, depot_dir)
-                    pkg"up --fixed"
+                    pkg"instantiate"
                     @test Pkg3.installed()[pkg2] == v"0.2.0"
                 end
             finally


### PR DESCRIPTION
can be used to instantiate a manifest without going through the resolver
also, show warning in status output about non downloaded packages

Closes https://github.com/JuliaLang/Pkg3.jl/issues/208