### PR TITLE
add an option to test in a "virgin environment" as would be the case when e.g. running on CI

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -204,7 +204,7 @@ test(pkg::Union{String, PackageSpec}; kwargs...)  = test([pkg]; kwargs...)
 test(pkgs::Vector{String}; kwargs...)             = test([PackageSpec(pkg) for pkg in pkgs]; kwargs...)
 test(pkgs::Vector{PackageSpec}; kwargs...)        = test(Context(), pkgs; kwargs...)
 
-function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...)
+function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, manifest=true, kwargs...)
     print_first_command_header()
     Context!(ctx; kwargs...)
     ctx.preview && preview_info()
@@ -217,7 +217,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, kwargs...
     project_deps_resolve!(ctx.env, pkgs)
     manifest_resolve!(ctx.env, pkgs)
     ensure_resolved(ctx.env, pkgs)
-    Operations.test(ctx, pkgs; coverage=coverage)
+    Operations.test(ctx, pkgs; coverage=coverage, manifest=manifest)
     return
 end
 

--- a/src/Operations.jl
+++ b/src/Operations.jl
@@ -699,7 +699,7 @@ end
 # at top level. Therefore we would like to execute the build or testing of a dependency using its own Project file as
 # the current environment. Being backwards compatible with REQUIRE file complicates the story a bit since these packages
 # do not have any Project files.
-function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::PackageSpec; might_need_to_resolve=false)
+function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::PackageSpec; might_need_to_resolve=false, use_manifest=true)
     # localctx is the context for the temporary environment we run the testing / building in
     localctx = deepcopy(mainctx)
     # If pkg or its dependencies are checked out, we will need to resolve
@@ -707,6 +707,8 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
     # with `might_need_to_resolve`
     need_to_resolve = false
     is_project = Types.is_project(localctx.env, pkg)
+
+    !use_manifest && empty!(localctx.env.manifest)
 
     if is_project
         foreach(k->delete!(localctx.env.project, k), ("name", "uuid", "version"))
@@ -735,10 +737,13 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         localctx.env.project_file = joinpath(tmpdir, "Project.toml")
         localctx.env.manifest_file = joinpath(tmpdir, "Manifest.toml")
         # Rewrite paths in Manifest since relative paths won't work here due to the temporary environment
-        for (_, infos) in localctx.env.manifest
-            info = infos[1]
-            if haskey(info, "path")
-                info["path"] = project_rel_path(mainctx, info["path"])
+        if use_manifest
+            for (depname, infos) in localctx.env.manifest
+                for info in infos
+                    if haskey(info, "path")
+                        info["path"] = project_rel_path(mainctx, info["path"])
+                    end
+                end
             end
         end
         # If pkg has a test only dependency, definitely need to resolve!
@@ -768,7 +773,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         end
 
         local new
-        will_resolve = might_need_to_resolve && need_to_resolve
+        will_resolve = (might_need_to_resolve && need_to_resolve) || !use_manifest
         if will_resolve
             resolve_versions!(localctx, pkgs)
             new = apply_versions(localctx, pkgs)
@@ -1040,7 +1045,7 @@ function free(ctx::Context, pkgs::Vector{PackageSpec})
     need_to_resolve && build_versions(ctx, new)
 end
 
-function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
+function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false, manifest=true)
     # See if we can find the test files for all packages
     missing_runtests = String[]
     testfiles        = String[]
@@ -1106,7 +1111,7 @@ function test(ctx::Context, pkgs::Vector{PackageSpec}; coverage=false)
                 push!(pkgs_errored, pkg.name)
             end
         end
-        with_dependencies_loadable_at_toplevel(ctx, pkg; might_need_to_resolve=true) do
+        with_dependencies_loadable_at_toplevel(ctx, pkg; might_need_to_resolve=true, use_manifest = manifest) do
             run_test()
         end
     end

--- a/src/REPLMode.jl
+++ b/src/REPLMode.jl
@@ -445,13 +445,16 @@ const helps = Dict(
     is modified.
     """, CMD_TEST => md"""
 
-        test [opts] pkg[=uuid] ...
+        test [-p|project]  [opts] pkg[=uuid] ...
+        test [-m|manifest] [opts] pkg[=uuid] ...
 
         opts: --coverage
 
     Run the tests for package `pkg`. This is done by running the file `test/runtests.jl`
-    in the package directory. The option `--coverage` can be used to run the tests with
-    coverage enabled.
+    in the package directory. If `project` is passed the versions in the current manifest
+    are ignores and new updated versions are resolved for the test. If `manifest` (default)
+    is passed, the versions in the current manifest are used for the tests.
+    The option `--coverage` can be used to run the tests with coverage enabled.
     """, CMD_GC => md"""
 
     Deletes packages that are not reached from any environment used within the last 6 weeks.
@@ -693,6 +696,7 @@ end
 function do_test!(ctx::Context, tokens::Vector{Token})
     pkgs = PackageSpec[]
     coverage = false
+    manifest = true
     while !isempty(tokens)
         token = popfirst!(tokens)
         if token isa String
@@ -702,6 +706,10 @@ function do_test!(ctx::Context, tokens::Vector{Token})
         elseif token isa Option
             if token.kind == OPT_COVERAGE
                 coverage = true
+            elseif token.kind == OPT_PROJECT
+                manifest = false
+            elseif token.kind == OPT_MANIFEST
+                manifest = true
             else
                 cmderror("invalid option for `test`: $token")
             end
@@ -710,7 +718,7 @@ function do_test!(ctx::Context, tokens::Vector{Token})
             cmderror("invalid usage for `test`")
         end
     end
-    API.test(ctx, pkgs; coverage = coverage)
+    API.test(ctx, pkgs; coverage = coverage, manifest = manifest)
 end
 
 function do_gc!(ctx::Context, tokens::Vector{Token})


### PR DESCRIPTION
This is what we discussed a bit @pfitzseb. Running e.g. `pkg> test --project JSON` will now ignore your manifest and run with freshly resolved dependencies, just like what would happen on CI.

TODO: Tests.